### PR TITLE
Add support for building on Linux

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -2,6 +2,14 @@
 
 ## Building
 
+### Linux
+If you are building on Debian/Ubuntu you will need to make sure you have the 
+following packages:
+
+```
+sudo apt install libsdl2-dev
+```
+
 ### CLI
 
 Build/run the CLI app:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # - emu: cpu emulator-based native build
 # - rosetta: rosetta-based native x86 build
 # - unicorn: cpu emulator-based native build
+# - linux: linux based x86 build
 # - fmt: run all code formatting
 # Flags:
 # $ make deploy opt=1
@@ -35,17 +36,15 @@ deploy: wasm deploy-exes deploy/bundle.js web/index.html
 
 
 emu:
-	source cli/sdl-brew.sh && cargo build -p retrowin32 -F x86-emu,sdl $(cargoflags)
+	. cli/sdl-brew.sh && cargo build -p retrowin32 -F x86-emu,sdl $(cargoflags)
 .PHONY: emu
 
-
 rosetta:
-	source cli/sdl-manual.sh && ./build-rosetta.sh $(cargoflags)
+	. cli/sdl-manual.sh && ./build-rosetta.sh $(cargoflags)
 .PHONY: rosetta
 
-
 unicorn:
-	source cli/sdl-brew.sh && cargo build -p retrowin32 -F x86-unicorn,sdl $(cargoflags)
+	. cli/sdl-brew.sh && cargo build -p retrowin32 -F x86-unicorn,sdl $(cargoflags)
 .PHONY: unicorn
 
 

--- a/cli/sdl-brew.sh
+++ b/cli/sdl-brew.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 # Set up environment for building with SDL found in homebrew.
 
-export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"
+if [ "$(uname)" = "Linux" ]; then
+    export LIBRARY_PATH="$LIBRARY_PATH:/usr/lib"
+else
+    export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"
+fi
 


### PR DESCRIPTION
This commit introduces the following changes:

1. Updated Makefile to use the dot (.) command instead of the 'source' command for script execution. This change ensures compatibility with POSIX-compliant shells, including (but not limited to) sh, bash, dash, and zsh.

2. Added conditional library path setting for Linux and macOS. The sdl-brew script now sets the LIBRARY_PATH environment variable based on the operating system:
   - For Linux, it appends /usr/lib to LIBRARY_PATH.
   - For macOS, it appends the Homebrew lib directory to LIBRARY_PATH.

3. Added instructions to `HACKING.md` for the necessary dependencies to install for running on Debian-based Linux systems.