### PR TITLE
Trace return values too

### DIFF
--- a/win32/derive/src/lib.rs
+++ b/win32/derive/src/lib.rs
@@ -3,16 +3,15 @@ mod parse;
 mod trace;
 
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+use quote::quote;
 
 #[proc_macro_attribute]
 pub fn dllexport(
     _attr: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let mut func: syn::ItemFn = syn::parse_macro_input!(item);
-    trace::add_trace(&mut func);
-    func.into_token_stream().into()
+    let func: syn::ItemFn = syn::parse_macro_input!(item);
+    trace::add_trace(func).into()
 }
 
 /// Generate a `shims` module that contains a wrapper for each function in this module

--- a/win32/derive/src/trace.rs
+++ b/win32/derive/src/trace.rs
@@ -1,34 +1,75 @@
-use quote::quote;
+use quote::{format_ident, quote};
 
 /// Insert a call to trace::trace() at the front of a function that logs its name and arguments.
 // TODO: this maybe belongs at the "impls" mod, so it can do its own traversal of the stack (?).
-pub fn add_trace(func: &mut syn::ItemFn) {
-    let name = func.sig.ident.to_string();
-    let mut args: Vec<&syn::Ident> = Vec::new();
-    for arg in func.sig.inputs.iter().skip(1) {
+pub fn add_trace(mut func: syn::ItemFn) -> proc_macro2::TokenStream {
+    let name = &func.sig.ident;
+    let name_string = name.to_string();
+    let mut arg_names: Vec<&syn::Ident> = Vec::new();
+    for arg in &func.sig.inputs {
         match arg {
             syn::FnArg::Typed(arg) => match &*arg.pat {
                 syn::Pat::Ident(pat) => {
-                    args.push(&pat.ident);
+                    arg_names.push(&pat.ident);
                 }
                 _ => {}
             },
             _ => {}
         };
     }
-    let synargs = args
+    let trace_arg_values = arg_names
         .iter()
+        .skip(1)
         .map(|arg| {
             let name = arg.to_string();
             quote!((#name, &#arg))
         })
         .collect::<Vec<_>>();
-    let arg_count = args.len();
-    let stmt: syn::Stmt = syn::parse_quote! {
-        if crate::trace::enabled(TRACE_CONTEXT) {
-            let args: &[(&str, &dyn std::fmt::Debug); #arg_count] = &[#(#synargs),*];
-            crate::trace::trace(TRACE_CONTEXT, std::file!(), std::line!(), #name, args);
+    let trace_arg_count = trace_arg_values.len();
+    let prolog = quote! {
+        let __trace_context = if crate::trace::enabled(TRACE_CONTEXT) {
+            let args: &[(&str, &dyn std::fmt::Debug); #trace_arg_count] = &[#(#trace_arg_values),*];
+            Some(crate::trace::trace_begin(TRACE_CONTEXT, #name_string, args))
+        } else {
+            None
+        };
+    };
+    let epilog = quote! {
+        if let Some(__trace_context) = __trace_context {
+            crate::trace::trace_return(&__trace_context, std::file!(), std::line!(), &__ret);
         }
     };
-    func.block.stmts.insert(0, stmt);
+
+    let trace_vis = func.vis.clone();
+    let mut trace_sig = func.sig.clone();
+    // Remove mutability and references from arguments.
+    for arg in &mut trace_sig.inputs {
+        match arg {
+            syn::FnArg::Typed(arg) => match &mut *arg.pat {
+                syn::Pat::Ident(pat) => {
+                    pat.by_ref = None;
+                    pat.mutability = None;
+                }
+                _ => {}
+            },
+            _ => {}
+        };
+    }
+
+    let impl_name = format_ident!("{}_impl", name);
+    func.sig.ident = impl_name.clone();
+    let await_t = if func.sig.asyncness.is_some() {
+        quote!(.await)
+    } else {
+        quote!()
+    };
+    quote! {
+        #trace_vis #trace_sig {
+            #func
+            #prolog
+            let __ret = #impl_name(#(#arg_names),*)#await_t;
+            #epilog
+            __ret
+        }
+    }
 }

--- a/win32/src/trace.rs
+++ b/win32/src/trace.rs
@@ -84,13 +84,7 @@ pub fn enabled(context: &'static str) -> bool {
 }
 
 #[inline(never)]
-pub fn trace(
-    context: &str,
-    file: &'static str,
-    line: u32,
-    func: &str,
-    args: &[(&str, &dyn std::fmt::Debug)],
-) {
+pub fn trace_begin(context: &str, func: &str, args: &[(&str, &dyn std::fmt::Debug)]) -> String {
     let mut msg = format!("{}/{}(", context, func);
     for (i, arg) in args.iter().enumerate() {
         if i > 0 {
@@ -99,13 +93,17 @@ pub fn trace(
         write!(&mut msg, "{}:{:x?}", arg.0, arg.1).unwrap();
     }
     msg.push_str(")");
+    msg
+}
 
+#[inline(never)]
+pub fn trace_return(context: &str, file: &'static str, line: u32, ret: &dyn std::fmt::Debug) {
     log::logger().log(
         &log::Record::builder()
             .level(log::Level::Info)
             .file(Some(file))
             .line(Some(line))
-            .args(format_args!("{}", msg))
+            .args(format_args!("{context} -> {ret:?}"))
             .build(),
     );
 }

--- a/win32/src/winapi/advapi32.rs
+++ b/win32/src/winapi/advapi32.rs
@@ -1,4 +1,4 @@
-#![allow(non_snake_case)]
+#![allow(non_snake_case, unused_variables)]
 
 use super::types::Str16;
 use crate::machine::Machine;

--- a/win32/src/winapi/bass.rs
+++ b/win32/src/winapi/bass.rs
@@ -5,7 +5,7 @@
 //! Today retrowin32 is capable of loading the dll, but it appears
 //! to be packed with some packer that fails when we load it.
 
-#![allow(non_snake_case)]
+#![allow(non_snake_case, unused_variables)]
 
 use super::kernel32;
 use crate::machine::Machine;

--- a/win32/src/winapi/builtin.rs
+++ b/win32/src/winapi/builtin.rs
@@ -497,8 +497,8 @@ pub mod gdi32 {
         }
         pub unsafe fn DeleteObject(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
-            let handle = <HGDIOBJ>::from_stack(mem, esp + 4u32);
-            winapi::gdi32::DeleteObject(machine, handle).to_raw()
+            let _handle = <HGDIOBJ>::from_stack(mem, esp + 4u32);
+            winapi::gdi32::DeleteObject(machine, _handle).to_raw()
         }
         pub unsafe fn GetDeviceCaps(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -3592,9 +3592,10 @@ pub mod vcruntime140 {
         use winapi::vcruntime140::*;
         pub unsafe fn _CxxThrowException(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
-            let pExceptionObject = <u32>::from_stack(mem, esp + 4u32);
-            let pThrowInfo = <u32>::from_stack(mem, esp + 8u32);
-            winapi::vcruntime140::_CxxThrowException(machine, pExceptionObject, pThrowInfo).to_raw()
+            let _pExceptionObject = <u32>::from_stack(mem, esp + 4u32);
+            let _pThrowInfo = <u32>::from_stack(mem, esp + 8u32);
+            winapi::vcruntime140::_CxxThrowException(machine, _pExceptionObject, _pThrowInfo)
+                .to_raw()
         }
         pub unsafe fn memcmp(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -3681,9 +3682,9 @@ pub mod version {
         use winapi::version::*;
         pub unsafe fn GetFileVersionInfoSizeA(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
-            let lptstrFilename = <Option<&str>>::from_stack(mem, esp + 4u32);
-            let lpdwHandle = <Option<&mut u32>>::from_stack(mem, esp + 8u32);
-            winapi::version::GetFileVersionInfoSizeA(machine, lptstrFilename, lpdwHandle).to_raw()
+            let _lptstrFilename = <Option<&str>>::from_stack(mem, esp + 4u32);
+            let _lpdwHandle = <Option<&mut u32>>::from_stack(mem, esp + 8u32);
+            winapi::version::GetFileVersionInfoSizeA(machine, _lptstrFilename, _lpdwHandle).to_raw()
         }
     }
     mod shims {

--- a/win32/src/winapi/ddraw/clipper.rs
+++ b/win32/src/winapi/ddraw/clipper.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use super::DD_OK;
 use crate::{
     winapi::{com::vtable, types::HWND},

--- a/win32/src/winapi/ddraw/ddraw1.rs
+++ b/win32/src/winapi/ddraw/ddraw1.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case, unused_variables)]
 //! Implementation of DirectDraw1 interfaces, which typically don't have
 //! a "1" suffix but contrast with intefaces with names like IDirectDraw7.
 

--- a/win32/src/winapi/ddraw/ddraw2.rs
+++ b/win32/src/winapi/ddraw/ddraw2.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case, unused_variables)]
 //! Implementation of DirectDraw2 interfaces.
 
 use super::{

--- a/win32/src/winapi/ddraw/ddraw7.rs
+++ b/win32/src/winapi/ddraw/ddraw7.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case, unused_variables)]
 //! Implementation of DirectDraw7 interfaces.
 
 use super::{palette::IDirectDrawPalette, types::*, DD_OK};

--- a/win32/src/winapi/ddraw/palette.rs
+++ b/win32/src/winapi/ddraw/palette.rs
@@ -41,7 +41,7 @@ pub mod IDirectDrawPalette {
     fn SetEntries(
         machine: &mut Machine,
         this: u32,
-        unused: u32,
+        _unused: u32,
         start: u32,
         count: u32,
         entries: u32,

--- a/win32/src/winapi/dsound.rs
+++ b/win32/src/winapi/dsound.rs
@@ -1,5 +1,4 @@
-#![allow(non_snake_case)]
-#![allow(non_upper_case_globals)]
+#![allow(non_snake_case, non_upper_case_globals, unused_variables)]
 
 use super::heap::Heap;
 pub use crate::winapi::com::GUID;

--- a/win32/src/winapi/gdi32/bitmap.rs
+++ b/win32/src/winapi/gdi32/bitmap.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use super::{BitmapType, DCTarget, Object, BITMAPINFOHEADER, HDC, HGDIOBJ};
 use crate::{
     machine::Machine,

--- a/win32/src/winapi/gdi32/dc.rs
+++ b/win32/src/winapi/gdi32/dc.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use super::{BitmapType, Object, HGDIOBJ, R2};
 use crate::{
     machine::Machine,

--- a/win32/src/winapi/gdi32/draw.rs
+++ b/win32/src/winapi/gdi32/draw.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case, unused_variables)]
 //! Pens, brushes, color.
 
 use super::{DCTarget, Object, CLR_INVALID, HDC, HGDIOBJ};

--- a/win32/src/winapi/gdi32/object.rs
+++ b/win32/src/winapi/gdi32/object.rs
@@ -131,7 +131,7 @@ pub fn GetObjectA(machine: &mut Machine, handle: HGDIOBJ, bytes: u32, out: u32) 
 }
 
 #[win32_derive::dllexport]
-pub fn DeleteObject(_machine: &mut Machine, handle: HGDIOBJ) -> bool {
+pub fn DeleteObject(_machine: &mut Machine, _handle: HGDIOBJ) -> bool {
     // TODO: leak
     true
 }

--- a/win32/src/winapi/gdi32/text.rs
+++ b/win32/src/winapi/gdi32/text.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use super::{CLR_INVALID, HDC};
 use crate::{
     winapi::{stack_args::ArrayWithSize, types::HANDLE},

--- a/win32/src/winapi/kernel32/dll.rs
+++ b/win32/src/winapi/kernel32/dll.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use memory::{Extensions, Pod};
 
 use crate::{

--- a/win32/src/winapi/kernel32/file.rs
+++ b/win32/src/winapi/kernel32/file.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use crate::str16::String16;
 use crate::winapi::kernel32::SetLastError;
 use crate::winapi::stack_args::ToX86;

--- a/win32/src/winapi/kernel32/ini.rs
+++ b/win32/src/winapi/kernel32/ini.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case, unused_variables)]
 //! Functions that work with .ini files.
 
 use crate::{

--- a/win32/src/winapi/kernel32/memory.rs
+++ b/win32/src/winapi/kernel32/memory.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use crate::{
     machine::{Machine, MemImpl},
     pe::ImageSectionFlags,

--- a/win32/src/winapi/kernel32/misc.rs
+++ b/win32/src/winapi/kernel32/misc.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case, unused_variables)]
 //! kernel32 API without a better home.
 
 use super::{teb_mut, WriteFile};

--- a/win32/src/winapi/kernel32/resource.rs
+++ b/win32/src/winapi/kernel32/resource.rs
@@ -1,4 +1,4 @@
-#![allow(non_snake_case)]
+#![allow(non_snake_case, unused_variables)]
 
 use crate::{
     pe,

--- a/win32/src/winapi/kernel32/sync.rs
+++ b/win32/src/winapi/kernel32/sync.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case, unused_variables)]
 //! Synchronization.  Currently all no-ops as we don't support threads.
 
 use crate::{winapi::types::HANDLE, Machine};

--- a/win32/src/winapi/kernel32/thread.rs
+++ b/win32/src/winapi/kernel32/thread.rs
@@ -1,4 +1,6 @@
-use super::{peb_mut, teb_mut};
+#![allow(non_snake_case, unused_variables)]
+
+use crate::winapi::kernel32::{peb_mut, teb_mut};
 use crate::{
     machine::Machine,
     winapi,

--- a/win32/src/winapi/ntdll.rs
+++ b/win32/src/winapi/ntdll.rs
@@ -1,5 +1,4 @@
-#![allow(non_snake_case)]
-#![allow(non_camel_case_types)]
+#![allow(non_snake_case, non_camel_case_types, unused_variables)]
 
 use crate::{
     machine::Machine,

--- a/win32/src/winapi/ucrtbase.rs
+++ b/win32/src/winapi/ucrtbase.rs
@@ -1,4 +1,4 @@
-#![allow(non_snake_case)]
+#![allow(non_snake_case, unused_variables)]
 
 use super::kernel32::ExitProcess;
 use crate::Machine;

--- a/win32/src/winapi/user32/dialog.rs
+++ b/win32/src/winapi/user32/dialog.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use crate::{winapi::types::*, Machine};
 
 const TRACE_CONTEXT: &'static str = "user32/dialog";

--- a/win32/src/winapi/user32/menu.rs
+++ b/win32/src/winapi/user32/menu.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use crate::{winapi::types::HWND, Machine};
 
 const TRACE_CONTEXT: &'static str = "user32/menu";

--- a/win32/src/winapi/user32/message.rs
+++ b/win32/src/winapi/user32/message.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use crate::{host, winapi::types::*, Machine, MouseButton};
 use bitflags::bitflags;
 

--- a/win32/src/winapi/user32/paint.rs
+++ b/win32/src/winapi/user32/paint.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use super::{UpdateRegion, HBRUSH, HDC};
 use crate::{
     winapi::{

--- a/win32/src/winapi/user32/resource.rs
+++ b/win32/src/winapi/user32/resource.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use super::HMENU;
 use crate::{
     pe,

--- a/win32/src/winapi/user32/window.rs
+++ b/win32/src/winapi/user32/window.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use super::*;
 use crate::{
     host,

--- a/win32/src/winapi/vcruntime140.rs
+++ b/win32/src/winapi/vcruntime140.rs
@@ -38,6 +38,6 @@ pub fn memcmp(machine: &mut Machine, lhs: u32, rhs: u32, len: u32) -> u32 {
 }
 
 #[win32_derive::dllexport(cdecl)]
-pub fn _CxxThrowException(_machine: &mut Machine, pExceptionObject: u32, pThrowInfo: u32) -> u32 {
+pub fn _CxxThrowException(_machine: &mut Machine, _pExceptionObject: u32, _pThrowInfo: u32) -> u32 {
     panic!("exception");
 }

--- a/win32/src/winapi/version.rs
+++ b/win32/src/winapi/version.rs
@@ -7,8 +7,8 @@ const TRACE_CONTEXT: &'static str = "version";
 #[win32_derive::dllexport]
 pub fn GetFileVersionInfoSizeA(
     _machine: &mut Machine,
-    lptstrFilename: Option<&str>,
-    lpdwHandle: Option<&mut u32>,
+    _lptstrFilename: Option<&str>,
+    _lpdwHandle: Option<&mut u32>,
 ) -> u32 {
     0 // TODO
 }

--- a/win32/src/winapi/winmm/time.rs
+++ b/win32/src/winapi/winmm/time.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use crate::machine::Machine;
 
 const TRACE_CONTEXT: &'static str = "winmm/time";

--- a/win32/src/winapi/winmm/wave.rs
+++ b/win32/src/winapi/winmm/wave.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case, unused_variables)]
+
 use crate::machine::Machine;
 use bitflags::bitflags;
 use memory::Pod;


### PR DESCRIPTION
Before, dllexport functions were generated like:
```rust
fn name(args) -> ret {
  trace(args);
  // ... user code
}
```
Now they look like:
```rust
fn name(args) -> ret {
  fn name_impl(args) -> ret {
    // ... user code
  }
  let ctx = trace_begin(args);
  let ret = name_impl(args);
  trace_return(ctx, ret);
  ret
}
```
The idea is to format the arguments _before_ running the impl, in case the impl modifies them. Then the log line is printed after the impl returns and includes the return value.

One interesting consequence of this approach is that dllexport impl arguments now are actually checked for unused-ness, since they're not considered used by the `trace` call. So I had to add `allow(unused_variables)` to a bunch of files. I think this is a good thing, though, and could later remove that `allow` when cleaning up files and renaming unused parameters to have a `_` prefix. I didn't do that in this PR, since that would be a massive changeset.

-----

One unsolved problem is with implementations calling other dllexport functions (for example, `ReadFile` 
calling `SetLastError`), `SetLastError`'s trace line will be printed before `ReadFile`'s trace line. One idea is to swap it around so it looks like:
```rust
fn name(args) -> ret {
  // ... user code
}
fn name_trace(args) -> ret {
  let ctx = trace_begin(args);
  let ret = name(args);
  trace_return(ctx, ret);
  ret
}
```
Then `builtin` would call the `name_trace` function instead. This way we can internally call other winapi functions without creating more trace logs. I tried this originally, but it required odd changes where modules that did `pub use module::InnerDllExport` to do `pub use module::InnerDllExport_trace`, which felt wrong. So I thought I'd submit it in its current state and revisit that later if you like this idea in general.

