### PR TITLE
fix some issues related to window messages

### DIFF
--- a/cli/src/sdl.rs
+++ b/cli/src/sdl.rs
@@ -45,6 +45,20 @@ fn message_from_event(hwnd: u32, event: sdl2::event::Event) -> Option<win32::Mes
                 y: y as u32,
             }),
         ),
+        sdl2::event::Event::MouseMotion {
+            timestamp,
+            x,
+            y,
+            ..
+        } => (
+            timestamp,
+            win32::MessageDetail::Mouse(win32::MouseMessage {
+                down: false,
+                button: win32::MouseButton::None,
+                x: x as u32,
+                y: y as u32,
+            }),
+        ),
         _ => {
             // log::warn!("unhandled event: {:?}", event);
             return None;

--- a/win32/src/host.rs
+++ b/win32/src/host.rs
@@ -97,6 +97,7 @@ pub struct Stat {
 
 #[derive(Debug, Clone, Copy)]
 pub enum MouseButton {
+    None,
     Left,
     Middle,
     Right,

--- a/win32/src/winapi/types.rs
+++ b/win32/src/winapi/types.rs
@@ -39,8 +39,8 @@ unsafe impl memory::Pod for POINT {}
 
 impl<'a> super::stack_args::FromStack<'a> for POINT {
     unsafe fn from_stack(mem: memory::Mem<'a>, sp: u32) -> Self {
-        let x = mem.get_pod::<u32>(sp + 4);
-        let y = mem.get_pod::<u32>(sp);
+        let x = mem.get_pod::<u32>(sp);
+        let y = mem.get_pod::<u32>(sp + 4);
         POINT { x, y }
     }
 }

--- a/win32/src/winapi/user32/message.rs
+++ b/win32/src/winapi/user32/message.rs
@@ -46,7 +46,7 @@ pub enum WM {
     ACTIVATEAPP = 0x001C,
     WINDOWPOSCHANGED = 0x0047,
     TIMER = 0x0113,
-    WM_MOUSEMOVE = 0x0200,
+    MOUSEMOVE = 0x0200,
     LBUTTONDOWN = 0x0201,
     LBUTTONUP = 0x0202,
     LBUTTONDBLCLK = 0x0203,
@@ -76,7 +76,7 @@ fn msg_from_message(message: host::Message) -> MSG {
         }
         host::MessageDetail::Mouse(mouse) => {
             msg.message = match (mouse.button, mouse.down) {
-                (MouseButton::None, _) => WM::WM_MOUSEMOVE,
+                (MouseButton::None, _) => WM::MOUSEMOVE,
                 (MouseButton::Left, true) => WM::LBUTTONDOWN,
                 (MouseButton::Left, false) => WM::LBUTTONUP,
                 (MouseButton::Right, true) => WM::RBUTTONDOWN,

--- a/win32/src/winapi/user32/message.rs
+++ b/win32/src/winapi/user32/message.rs
@@ -46,6 +46,7 @@ pub enum WM {
     ACTIVATEAPP = 0x001C,
     WINDOWPOSCHANGED = 0x0047,
     TIMER = 0x0113,
+    WM_MOUSEMOVE = 0x0200,
     LBUTTONDOWN = 0x0201,
     LBUTTONUP = 0x0202,
     LBUTTONDBLCLK = 0x0203,
@@ -75,6 +76,7 @@ fn msg_from_message(message: host::Message) -> MSG {
         }
         host::MessageDetail::Mouse(mouse) => {
             msg.message = match (mouse.button, mouse.down) {
+                (MouseButton::None, _) => WM::WM_MOUSEMOVE,
                 (MouseButton::Left, true) => WM::LBUTTONDOWN,
                 (MouseButton::Left, false) => WM::LBUTTONUP,
                 (MouseButton::Right, true) => WM::RBUTTONDOWN,
@@ -84,6 +86,8 @@ fn msg_from_message(message: host::Message) -> MSG {
             } as u32;
             msg.wParam = 0; // TODO:  modifiers
             msg.lParam = (mouse.y << 16) | mouse.x;
+            msg.pt_x = mouse.x;
+            msg.pt_y = mouse.y;
         }
     }
 
@@ -114,10 +118,6 @@ fn enqueue_timer_event_if_ready(machine: &mut Machine, hwnd: HWND) -> Result<(),
 /// Returns Ok if an event is enqueued.
 /// Returns Err(wait) if we need to wait for an event.
 fn fill_message_queue(machine: &mut Machine, hwnd: HWND) -> Result<(), Option<u32>> {
-    if !machine.state.user32.messages.is_empty() {
-        return Ok(());
-    }
-
     if let Some(msg) = machine.host.get_message() {
         machine
             .state
@@ -199,6 +199,25 @@ fn enqueue_paint_if_needed(machine: &mut Machine, hwnd: HWND) -> bool {
     true
 }
 
+fn find_message(machine: &mut Machine, hwnd: HWND, min: u32, max: u32) -> Option<usize> {
+    machine.state.user32.messages.iter().position(|msg| {
+        if !hwnd.is_null() && (!msg.hwnd.is_null() && msg.hwnd != hwnd) {
+            return false;
+        }
+        if min != 0 && max != 0 && (msg.message < min || msg.message > max) {
+            return false;
+        }
+        true
+    })
+}
+
+fn copy_message(dstMsg: &mut MSG, srcMsg: &MSG) {
+    // Old versions of MSG don't have the lPrivate field. It might point to another stack variable, so don't overwrite it.
+    let dst = unsafe { std::slice::from_raw_parts_mut(dstMsg as *mut MSG as *mut u8, 28) };
+    let src = unsafe { std::slice::from_raw_parts(srcMsg as *const MSG as *const u8, 28) };
+    dst.copy_from_slice(src);
+}
+
 #[win32_derive::dllexport]
 pub fn PeekMessageA(
     machine: &mut Machine,
@@ -208,27 +227,19 @@ pub fn PeekMessageA(
     wMsgFilterMax: u32,
     wRemoveMsg: Result<RemoveMsg, u32>,
 ) -> bool {
-    assert_eq!(wMsgFilterMin, 0);
-    assert_eq!(wMsgFilterMax, 0);
     let lpMsg = lpMsg.unwrap();
 
     let _ = fill_message_queue(machine, hWnd);
 
-    let msg: &MSG = match machine.state.user32.messages.front() {
-        Some(msg) => msg,
-        None => return false,
-    };
-    if !hWnd.is_null() && (!msg.hwnd.is_null() && msg.hwnd != hWnd) {
-        todo!("message for other window");
+    if let Some(index) = find_message(machine, hWnd, wMsgFilterMin, wMsgFilterMax) {
+        copy_message(lpMsg, machine.state.user32.messages.get(index).unwrap());
+        let remove = wRemoveMsg.unwrap();
+        if remove.contains(RemoveMsg::PM_REMOVE) {
+            machine.state.user32.messages.remove(index);
+        }
+        return true;
     }
-    *lpMsg = msg.clone();
-
-    let remove = wRemoveMsg.unwrap();
-    if remove.contains(RemoveMsg::PM_REMOVE) {
-        machine.state.user32.messages.pop_front();
-    }
-
-    true
+    false
 }
 
 #[win32_derive::dllexport]
@@ -268,13 +279,13 @@ pub async fn GetMessageA(
         }
     }
 
-    let msg = lpMsg.unwrap();
-    *msg = machine.state.user32.messages.pop_front().unwrap();
-    if !hWnd.is_null() && (!msg.hwnd.is_null() && msg.hwnd != hWnd) {
-        todo!("message for other window");
-    }
-    if msg.message == WM::QUIT as u32 {
-        return 0;
+    if let Some(index) = find_message(machine, hWnd, wMsgFilterMin, wMsgFilterMax) {
+        let msg = machine.state.user32.messages.get(index).unwrap().clone();
+        machine.state.user32.messages.remove(index);
+        copy_message(lpMsg.unwrap(), &msg);
+        if msg.message == WM::QUIT as u32 {
+            return 0;
+        }
     }
     return 1;
 }

--- a/win32/src/winapi/user32/timer.rs
+++ b/win32/src/winapi/user32/timer.rs
@@ -76,11 +76,14 @@ pub fn SetTimer(
         .user32
         .timers
         .0
-        .iter()
+        .iter_mut()
         .find(|t| t.hwnd == hWnd && t.id == nIDEvent)
     {
-        Some(_) => {
-            todo!("update existing timer");
+        Some(timer) => {
+            timer.period = uElapse;
+            timer.next = machine.host.time() + uElapse;
+            timer.func = lpTimerFunc;
+            timer.id
         }
         None => {
             let id = machine.state.user32.timers.0.len() as u32 + 1;


### PR DESCRIPTION
This pull request improves window message handling with the following updates:

- Implement message filter in `GetMessage` / `PeekMessage`
- Fix `<POINT>::from_stack` order bug
- Populate mouse position in `MSG`
- Add mouse move event for SDL
- Allow timer updates
- Correct `MSG` size for pre-Win2k executables

After these fixes, you can restart the game in Minesweeper, making it more enjoyable!
