### PR TITLE
Some CRT implementations

### DIFF
--- a/win32/src/machine_emu.rs
+++ b/win32/src/machine_emu.rs
@@ -179,7 +179,11 @@ impl MachineX<Emulator> {
         self.emu.x86.execute_block(self.emu.memory.mem())
     }
 
-    pub fn call_x86(&mut self, func: u32, args: Vec<u32>) -> impl std::future::Future {
+    pub fn call_x86(
+        &mut self,
+        func: u32,
+        args: Vec<u32>,
+    ) -> impl std::future::Future<Output = u32> {
         self.emu
             .x86
             .cpu_mut()

--- a/win32/src/machine_raw.rs
+++ b/win32/src/machine_raw.rs
@@ -75,7 +75,11 @@ impl MachineX<Emulator> {
         })
     }
 
-    pub fn call_x86(&mut self, func: u32, args: Vec<u32>) -> impl std::future::Future {
+    pub fn call_x86(
+        &mut self,
+        func: u32,
+        args: Vec<u32>,
+    ) -> impl std::future::Future<Output = u32> {
         crate::shims_raw::call_x86(self, func, args)
     }
 

--- a/win32/src/machine_unicorn.rs
+++ b/win32/src/machine_unicorn.rs
@@ -194,7 +194,11 @@ impl MachineX<Emulator> {
         })
     }
 
-    pub fn call_x86(&mut self, func: u32, args: Vec<u32>) -> impl std::future::Future {
+    pub fn call_x86(
+        &mut self,
+        func: u32,
+        args: Vec<u32>,
+    ) -> impl std::future::Future<Output = u32> {
         crate::shims_unicorn::call_x86(self, func, args)
     }
 }

--- a/win32/src/shims.rs
+++ b/win32/src/shims.rs
@@ -26,15 +26,25 @@ pub struct Shim {
     pub is_async: bool,
 }
 
-pub struct UnimplFuture {}
-impl std::future::Future for UnimplFuture {
-    type Output = ();
+pub struct UnimplFuture<T = ()> {
+    pub value: T,
+}
+impl<T> UnimplFuture<T> {
+    pub fn new(value: T) -> Self {
+        UnimplFuture { value }
+    }
+}
+impl<T> std::future::Future for UnimplFuture<T>
+where
+    T: Clone,
+{
+    type Output = T;
 
     fn poll(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        std::task::Poll::Ready(())
+        std::task::Poll::Ready(self.value.clone())
     }
 }
 

--- a/win32/src/shims_unicorn.rs
+++ b/win32/src/shims_unicorn.rs
@@ -98,7 +98,7 @@ fn handle_shim_call(machine: &mut Machine) -> u32 {
     ret_addr
 }
 
-pub fn call_x86(machine: &mut Machine, func: u32, args: Vec<u32>) -> UnimplFuture {
+pub fn call_x86(machine: &mut Machine, func: u32, args: Vec<u32>) -> UnimplFuture<u32> {
     let mem = machine.emu.memory.mem();
 
     let ret_addr = machine
@@ -127,7 +127,12 @@ pub fn call_x86(machine: &mut Machine, func: u32, args: Vec<u32>) -> UnimplFutur
 
     unicorn_loop(machine, func, ret_addr);
 
-    UnimplFuture {}
+    let ret = machine
+        .emu
+        .unicorn
+        .reg_read(unicorn_engine::RegisterX86::EAX)
+        .unwrap() as u32;
+    UnimplFuture::new(ret)
 }
 
 /// Run emulation via machine.emu starting from eip=begin until eip==until is hit.

--- a/win32/src/winapi/ucrtbase.rs
+++ b/win32/src/winapi/ucrtbase.rs
@@ -6,12 +6,37 @@ use crate::Machine;
 const TRACE_CONTEXT: &'static str = "ucrtbase";
 
 #[win32_derive::dllexport(cdecl)]
-pub fn _initterm(_machine: &mut Machine, start: u32, end: u32) -> u32 {
+pub async fn _initterm(machine: &mut Machine, start: u32, end: u32) -> u32 {
+    if (end - start) % 4 != 0 {
+        panic!("unaligned _initterm");
+    }
+    let slice = machine.mem().sub(start, end - start).as_slice_todo();
+    let slice =
+        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u32, slice.len() / 4) };
+    for &addr in slice {
+        if addr != 0 {
+            machine.call_x86(addr, vec![]).await;
+        }
+    }
     0
 }
 
 #[win32_derive::dllexport(cdecl)]
-pub fn _initterm_e(_machine: &mut Machine, start: u32, end: u32) -> u32 {
+pub async fn _initterm_e(machine: &mut Machine, start: u32, end: u32) -> u32 {
+    if (end - start) % 4 != 0 {
+        panic!("unaligned _initterm_e");
+    }
+    let slice = machine.mem().sub(start, end - start).as_slice_todo();
+    let slice =
+        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u32, slice.len() / 4) };
+    for &addr in slice {
+        if addr != 0 {
+            let err = machine.call_x86(addr, vec![]).await;
+            if err != 0 {
+                return err;
+            }
+        }
+    }
     0
 }
 
@@ -47,5 +72,24 @@ pub fn _unlock(_machine: &mut Machine, locknum: u32) -> u32 {
 
 #[win32_derive::dllexport(cdecl)]
 pub fn __dllonexit(_machine: &mut Machine, func: u32, d: u32, f: u32) -> u32 {
+    0
+}
+
+#[win32_derive::dllexport(cdecl)]
+pub fn malloc(machine: &mut Machine, size: u32) -> u32 {
+    let heap = machine
+        .state
+        .kernel32
+        .get_process_heap(&mut machine.emu.memory); // lazy init process_heap
+    heap.alloc(machine.emu.memory.mem(), size)
+}
+
+#[win32_derive::dllexport(cdecl)]
+pub fn free(machine: &mut Machine, ptr: u32) -> u32 {
+    let heap = machine
+        .state
+        .kernel32
+        .get_process_heap(&mut machine.emu.memory); // lazy init process_heap
+    heap.free(machine.emu.memory.mem(), ptr);
     0
 }

--- a/x86/src/x86.rs
+++ b/x86/src/x86.rs
@@ -134,7 +134,7 @@ pub struct X86Future {
     esp: u32,
 }
 impl std::future::Future for X86Future {
-    type Output = ();
+    type Output = u32;
 
     fn poll(
         self: std::pin::Pin<&mut Self>,
@@ -143,7 +143,7 @@ impl std::future::Future for X86Future {
         let cpu = self.cpu;
         let cpu = unsafe { &mut *cpu };
         if cpu.regs.get32(Register::ESP) == self.esp {
-            std::task::Poll::Ready(())
+            std::task::Poll::Ready(cpu.regs.get32(Register::EAX))
         } else {
             std::task::Poll::Pending
         }


### PR DESCRIPTION
Implements `_initterm`, `_initterm_e`, `malloc` and `free`.

Updates `Machine::call_x86` to return EAX.
