### PR TITLE
Add function name to trace context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +473,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "unicorn-engine"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +569,7 @@ dependencies = [
  "bincode",
  "bitflags",
  "chrono",
+ "const_format",
  "log",
  "memory",
  "num-derive",

--- a/win32/Cargo.toml
+++ b/win32/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0"
 bincode = "1.3.3"
 bitflags = "1.3.2"
 chrono = "0.4.38"
+const_format = "0.2.32"
 num-derive = "0.3"
 num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/win32/derive/src/trace.rs
+++ b/win32/derive/src/trace.rs
@@ -27,7 +27,7 @@ pub fn add_trace(mut func: syn::ItemFn) -> proc_macro2::TokenStream {
         .collect::<Vec<_>>();
     let trace_arg_count = trace_arg_values.len();
     let prolog = quote! {
-        let __trace_context = if crate::trace::enabled(TRACE_CONTEXT) {
+        let __trace_context = if crate::trace::enabled(const_format::concatcp!(TRACE_CONTEXT, "/", #name_string)) {
             let args: &[(&str, &dyn std::fmt::Debug); #trace_arg_count] = &[#(#trace_arg_values),*];
             Some(crate::trace::trace_begin(TRACE_CONTEXT, #name_string, args))
         } else {


### PR DESCRIPTION
Allows enabling/disabling individual functions with `--win32-trace`.