### PR TITLE
Implement FileTimeToSystemTime, FormatMessageA (stub)

### DIFF
--- a/win32/src/winapi/builtin.rs
+++ b/win32/src/winapi/builtin.rs
@@ -1117,6 +1117,12 @@ pub mod kernel32 {
             let uExitCode = <u32>::from_stack(mem, esp + 4u32);
             winapi::kernel32::ExitProcess(machine, uExitCode).to_raw()
         }
+        pub unsafe fn FileTimeToSystemTime(machine: &mut Machine, esp: u32) -> u32 {
+            let mem = machine.mem().detach();
+            let lpFileTime = <Option<&FILETIME>>::from_stack(mem, esp + 4u32);
+            let lpSystemTime = <Option<&mut SYSTEMTIME>>::from_stack(mem, esp + 8u32);
+            winapi::kernel32::FileTimeToSystemTime(machine, lpFileTime, lpSystemTime).to_raw()
+        }
         pub unsafe fn FindClose(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
             let hFindFile = <HFIND>::from_stack(mem, esp + 4u32);
@@ -1147,6 +1153,27 @@ pub mod kernel32 {
             let lpName = <ResourceKey<&Str16>>::from_stack(mem, esp + 8u32);
             let lpType = <ResourceKey<&Str16>>::from_stack(mem, esp + 12u32);
             winapi::kernel32::FindResourceW(machine, hModule, lpName, lpType).to_raw()
+        }
+        pub unsafe fn FormatMessageA(machine: &mut Machine, esp: u32) -> u32 {
+            let mem = machine.mem().detach();
+            let dwFlags = <u32>::from_stack(mem, esp + 4u32);
+            let lpSource = <u32>::from_stack(mem, esp + 8u32);
+            let dwMessageId = <u32>::from_stack(mem, esp + 12u32);
+            let dwLanguageId = <u32>::from_stack(mem, esp + 16u32);
+            let lpBuffer = <u32>::from_stack(mem, esp + 20u32);
+            let nSize = <u32>::from_stack(mem, esp + 24u32);
+            let args = <u32>::from_stack(mem, esp + 28u32);
+            winapi::kernel32::FormatMessageA(
+                machine,
+                dwFlags,
+                lpSource,
+                dwMessageId,
+                dwLanguageId,
+                lpBuffer,
+                nSize,
+                args,
+            )
+            .to_raw()
         }
         pub unsafe fn FormatMessageW(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -2097,6 +2124,12 @@ pub mod kernel32 {
             stack_consumed: 4u32,
             is_async: false,
         };
+        pub const FileTimeToSystemTime: Shim = Shim {
+            name: "FileTimeToSystemTime",
+            func: impls::FileTimeToSystemTime,
+            stack_consumed: 8u32,
+            is_async: false,
+        };
         pub const FindClose: Shim = Shim {
             name: "FindClose",
             func: impls::FindClose,
@@ -2125,6 +2158,12 @@ pub mod kernel32 {
             name: "FindResourceW",
             func: impls::FindResourceW,
             stack_consumed: 12u32,
+            is_async: false,
+        };
+        pub const FormatMessageA: Shim = Shim {
+            name: "FormatMessageA",
+            func: impls::FormatMessageA,
+            stack_consumed: 28u32,
             is_async: false,
         };
         pub const FormatMessageW: Shim = Shim {
@@ -2836,7 +2875,7 @@ pub mod kernel32 {
             is_async: true,
         };
     }
-    const EXPORTS: [Symbol; 136usize] = [
+    const EXPORTS: [Symbol; 138usize] = [
         Symbol {
             ordinal: None,
             shim: shims::AcquireSRWLockExclusive,
@@ -2891,6 +2930,10 @@ pub mod kernel32 {
         },
         Symbol {
             ordinal: None,
+            shim: shims::FileTimeToSystemTime,
+        },
+        Symbol {
+            ordinal: None,
             shim: shims::FindClose,
         },
         Symbol {
@@ -2908,6 +2951,10 @@ pub mod kernel32 {
         Symbol {
             ordinal: None,
             shim: shims::FindResourceW,
+        },
+        Symbol {
+            ordinal: None,
+            shim: shims::FormatMessageA,
         },
         Symbol {
             ordinal: None,

--- a/win32/src/winapi/kernel32/misc.rs
+++ b/win32/src/winapi/kernel32/misc.rs
@@ -431,3 +431,22 @@ pub fn GetWindowsDirectoryA(machine: &mut Machine, lpBuffer: u32, uSize: u32) ->
     }
     path_bytes.len() as u32
 }
+
+#[win32_derive::dllexport]
+pub fn FormatMessageA(
+    machine: &mut Machine,
+    dwFlags: u32,
+    lpSource: u32,
+    dwMessageId: u32,
+    dwLanguageId: u32,
+    lpBuffer: u32,
+    nSize: u32,
+    args: u32,
+) -> u32 {
+    log::warn!("FormatMessageA: stub");
+    if lpBuffer != 0 && nSize > 0 {
+        let mem = machine.mem().sub(lpBuffer, nSize).as_mut_slice_todo();
+        mem[0] = 0;
+    }
+    0
+}

--- a/win32/src/winapi/types.rs
+++ b/win32/src/winapi/types.rs
@@ -85,7 +85,22 @@ pub fn io_error_to_win32(err: &std::io::Error) -> u32 {
 pub const MAX_PATH: usize = 260;
 
 #[inline]
-pub fn unix_nanos_to_filetime(nanos: u64) -> u64 {
+pub fn unix_nanos_to_filetime(nanos: i64) -> u64 {
     // 100ns intervals since 1601-01-01
-    (nanos / 100) + 11_644_473_600_000_000
+    let hnsecs = nanos
+        .div_euclid(100)
+        .saturating_add(116_444_736_000_000_000);
+    if hnsecs < 0 {
+        0
+    } else {
+        hnsecs as u64
+    }
+}
+
+#[inline]
+pub fn filetime_to_unix_nanos(filetime: u64) -> i64 {
+    if filetime > i64::MAX as u64 {
+        return i64::MAX;
+    }
+    (filetime as i64).saturating_sub(116_444_736_000_000_000) * 100
 }


### PR DESCRIPTION
Other changes:
- Reworks FILETIME handling a bit
- Makes host.canonicalize normalize the path without it having to exist (matches GetFullPathName behavior)
- Zeroes `lpNumberOfBytesWritten` at the beginning of ReadFile/WriteFile