### PR TITLE
memory iterator

### DIFF
--- a/win32/src/winapi/ucrtbase.rs
+++ b/win32/src/winapi/ucrtbase.rs
@@ -2,6 +2,7 @@
 
 use super::kernel32::ExitProcess;
 use crate::Machine;
+use memory::Extensions;
 
 const TRACE_CONTEXT: &'static str = "ucrtbase";
 
@@ -10,10 +11,9 @@ pub async fn _initterm(machine: &mut Machine, start: u32, end: u32) -> u32 {
     if (end - start) % 4 != 0 {
         panic!("unaligned _initterm");
     }
-    let slice = machine.mem().sub(start, end - start).as_slice_todo();
-    let slice =
-        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u32, slice.len() / 4) };
-    for &addr in slice {
+    // Safety: iterating memory while calling x86 can potentially invalidate the memory.
+    let slice = unsafe { machine.mem().sub(start, end - start).detach() };
+    for addr in slice.into_iter_pod::<u32>() {
         if addr != 0 {
             machine.call_x86(addr, vec![]).await;
         }
@@ -26,10 +26,9 @@ pub async fn _initterm_e(machine: &mut Machine, start: u32, end: u32) -> u32 {
     if (end - start) % 4 != 0 {
         panic!("unaligned _initterm_e");
     }
-    let slice = machine.mem().sub(start, end - start).as_slice_todo();
-    let slice =
-        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u32, slice.len() / 4) };
-    for &addr in slice {
+    // Safety: iterating memory while calling x86 can potentially invalidate the memory.
+    let slice = unsafe { machine.mem().sub(start, end - start).detach() };
+    for addr in slice.into_iter_pod() {
         if addr != 0 {
             let err = machine.call_x86(addr, vec![]).await;
             if err != 0 {


### PR DESCRIPTION
I realized there is a better API for iterating some pod data in memory, and also that iterating while executing x86 code is unsafe because memory could move out from underneath.  I think the only ok thing to do here is copy.

CC @encounter 
