### PR TITLE
WIP GDB stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +142,119 @@ name = "exe"
 version = "0.1.0"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "gdbstub"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6341b3480afbb34eaefc7f92713bc92f2d83e338aaa1c44192f9c2956f4a4903"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "log",
+ "managed",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "gdbstub_arch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3b1357bd3203fc09a6601327ae0ab38865d14231d0b65d3143f5762cc7977d"
+dependencies = [
+ "gdbstub",
+ "num-traits",
 ]
 
 [[package]]
@@ -234,6 +353,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "memory"
 version = "0.1.0"
 
@@ -280,6 +411,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +459,8 @@ dependencies = [
  "anyhow",
  "argh",
  "chrono",
+ "gdbstub",
+ "gdbstub_arch",
  "iced-x86",
  "libc",
  "log",
@@ -332,7 +483,7 @@ version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7959277b623f1fb9e04aea73686c3ca52f01b2145f8ea16f4ff30d8b7623b1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "lazy_static",
  "libc",
  "sdl2-sys",
@@ -401,6 +552,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,7 +625,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3b881bfd9837ff4f62e81a1e64b40a584604375ae0a73d0d5f09b7a72350b96"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cmake",
  "libc",
@@ -548,8 +708,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
- "bitflags",
+ "bitflags 1.3.2",
  "chrono",
+ "futures",
  "log",
  "memory",
  "num-derive",
@@ -661,7 +822,8 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 name = "x86"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+ "futures",
  "iced-x86",
  "log",
  "memory",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,8 @@ win32 = { workspace = true }
 anyhow = "1.0"
 argh = "0.1.10"
 chrono = "0.4.38"
+gdbstub = "0.7.1"
+gdbstub_arch = "0.3.0"
 libc = "0.2"
 typed-path = "0.9.1"
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -1,0 +1,839 @@
+use gdbstub::arch::Arch;
+use gdbstub::common::Pid;
+use gdbstub::stub::state_machine::GdbStubStateMachine;
+use gdbstub::stub::{BaseStopReason, SingleThreadStopReason};
+use gdbstub::target::ext::base::singlethread::{
+    SingleThreadRangeSteppingOps, SingleThreadSingleStep, SingleThreadSingleStepOps,
+};
+use gdbstub::target::ext::breakpoints::{
+    Breakpoints, BreakpointsOps, SwBreakpoint, SwBreakpointOps,
+};
+use gdbstub::target::ext::exec_file::{ExecFile, ExecFileOps};
+use gdbstub::target::ext::host_io::{
+    HostIo, HostIoClose, HostIoCloseOps, HostIoError, HostIoOpen, HostIoOpenFlags, HostIoOpenMode,
+    HostIoOpenOps, HostIoOps, HostIoPread, HostIoPreadOps, HostIoPwriteOps, HostIoResult,
+};
+use gdbstub::target::{Target, TargetError, TargetResult};
+use gdbstub::{
+    common::Signal,
+    stub::GdbStub,
+    target::ext::base::{
+        single_register_access::{SingleRegisterAccess, SingleRegisterAccessOps},
+        singlethread::{SingleThreadBase, SingleThreadResume, SingleThreadResumeOps},
+        BaseOps,
+    },
+};
+use std::io::ErrorKind;
+use win32::mem::ExtensionsMut;
+use win32::Machine;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum MachineTargetAction {
+    Stop,
+    Resume,
+    SingleStep,
+}
+
+pub struct MachineTarget {
+    pub machine: Machine,
+    action: Option<MachineTargetAction>,
+}
+
+impl MachineTarget {
+    pub fn new(machine: Machine) -> Self {
+        MachineTarget {
+            machine,
+            action: None,
+        }
+    }
+}
+
+impl Target for MachineTarget {
+    type Arch = gdbstub_arch::x86::X86_SSE;
+    type Error = std::io::Error;
+
+    fn base_ops(&mut self) -> BaseOps<'_, Self::Arch, Self::Error> {
+        BaseOps::SingleThread(self)
+    }
+
+    fn support_breakpoints(&mut self) -> Option<BreakpointsOps<'_, Self>> {
+        Some(self)
+    }
+
+    fn support_host_io(&mut self) -> Option<HostIoOps<'_, Self>> {
+        Some(self)
+    }
+
+    fn support_exec_file(&mut self) -> Option<ExecFileOps<'_, Self>> {
+        Some(self)
+    }
+}
+
+#[cfg(feature = "x86-emu")]
+impl SingleThreadBase for MachineTarget {
+    fn read_registers(
+        &mut self,
+        regs: &mut <Self::Arch as Arch>::Registers,
+    ) -> TargetResult<(), Self> {
+        use gdbstub_arch::x86::reg::F80;
+        let cpu = self.machine.emu.x86.cpu();
+        regs.eax = cpu.regs.get32(x86::Register::EAX);
+        regs.ecx = cpu.regs.get32(x86::Register::ECX);
+        regs.edx = cpu.regs.get32(x86::Register::EDX);
+        regs.ebx = cpu.regs.get32(x86::Register::EBX);
+        regs.esp = cpu.regs.get32(x86::Register::ESP);
+        regs.ebp = cpu.regs.get32(x86::Register::EBP);
+        regs.esi = cpu.regs.get32(x86::Register::ESI);
+        regs.edi = cpu.regs.get32(x86::Register::EDI);
+        regs.eip = cpu.regs.eip;
+        regs.eflags = cpu.flags.bits();
+        regs.segments.cs = 0; // TODO
+        regs.segments.ss = 0; // TODO
+        regs.segments.ds = 0; // TODO
+        regs.segments.es = 0; // TODO
+        regs.segments.fs = 0; // TODO
+        regs.segments.gs = 0; // TODO
+        regs.st.fill(F80::default()); // TODO
+        regs.xmm.fill(0u128); // TODO
+        regs.mxcsr = 0; // TODO
+        Ok(())
+    }
+
+    fn write_registers(
+        &mut self,
+        regs: &<Self::Arch as Arch>::Registers,
+    ) -> TargetResult<(), Self> {
+        let cpu = self.machine.emu.x86.cpu_mut();
+        cpu.regs.set32(x86::Register::EAX, regs.eax);
+        cpu.regs.set32(x86::Register::ECX, regs.ecx);
+        cpu.regs.set32(x86::Register::EDX, regs.edx);
+        cpu.regs.set32(x86::Register::EBX, regs.ebx);
+        cpu.regs.set32(x86::Register::ESP, regs.esp);
+        cpu.regs.set32(x86::Register::EBP, regs.ebp);
+        cpu.regs.set32(x86::Register::ESI, regs.esi);
+        cpu.regs.set32(x86::Register::EDI, regs.edi);
+        cpu.regs.eip = regs.eip;
+        cpu.flags = x86::Flags::from_bits_truncate(regs.eflags);
+        // TODO: segments, st, xmm, mxcsr
+        Ok(())
+    }
+
+    fn support_single_register_access(&mut self) -> Option<SingleRegisterAccessOps<'_, (), Self>> {
+        Some(self)
+    }
+
+    fn read_addrs(
+        &mut self,
+        start_addr: <Self::Arch as Arch>::Usize,
+        data: &mut [u8],
+    ) -> TargetResult<usize, Self> {
+        let mem = self.machine.mem();
+        let slice = if start_addr > mem.len() {
+            return Ok(0);
+        } else if start_addr + data.len() as u32 > mem.len() {
+            mem.sub(start_addr, mem.len() - start_addr).as_slice_todo()
+        } else {
+            mem.sub(start_addr, data.len() as u32).as_slice_todo()
+        };
+        data[..slice.len()].copy_from_slice(slice);
+        Ok(slice.len())
+    }
+
+    fn write_addrs(
+        &mut self,
+        start_addr: <Self::Arch as Arch>::Usize,
+        data: &[u8],
+    ) -> TargetResult<(), Self> {
+        self.machine
+            .mem()
+            .sub32_mut(start_addr, data.len() as u32)
+            .copy_from_slice(data);
+        Ok(())
+    }
+
+    fn support_resume(&mut self) -> Option<SingleThreadResumeOps<'_, Self>> {
+        Some(self)
+    }
+}
+
+#[cfg(feature = "x86-emu")]
+impl SingleRegisterAccess<()> for MachineTarget {
+    fn read_register(
+        &mut self,
+        _tid: (),
+        reg_id: <Self::Arch as Arch>::RegId,
+        buf: &mut [u8],
+    ) -> TargetResult<usize, Self> {
+        use gdbstub_arch::x86::reg::id::X86CoreRegId;
+        let cpu = self.machine.emu.x86.cpu();
+        fn reg_read_u32(
+            cpu: &x86::CPU,
+            buf: &mut [u8],
+            reg: x86::Register,
+        ) -> TargetResult<usize, MachineTarget> {
+            let value = cpu.regs.get32(reg);
+            buf.copy_from_slice(&value.to_le_bytes());
+            Ok(4)
+        }
+        match reg_id {
+            X86CoreRegId::Eax => reg_read_u32(cpu, buf, x86::Register::EAX),
+            X86CoreRegId::Ecx => reg_read_u32(cpu, buf, x86::Register::ECX),
+            X86CoreRegId::Edx => reg_read_u32(cpu, buf, x86::Register::EDX),
+            X86CoreRegId::Ebx => reg_read_u32(cpu, buf, x86::Register::EBX),
+            X86CoreRegId::Esp => reg_read_u32(cpu, buf, x86::Register::ESP),
+            X86CoreRegId::Ebp => reg_read_u32(cpu, buf, x86::Register::EBP),
+            X86CoreRegId::Esi => reg_read_u32(cpu, buf, x86::Register::ESI),
+            X86CoreRegId::Edi => reg_read_u32(cpu, buf, x86::Register::EDI),
+            X86CoreRegId::Eip => {
+                buf.copy_from_slice(&cpu.regs.eip.to_le_bytes());
+                Ok(4)
+            }
+            X86CoreRegId::Eflags => {
+                buf.copy_from_slice(&cpu.flags.bits().to_le_bytes());
+                Ok(4)
+            }
+            X86CoreRegId::Segment(_reg_id) => {
+                // TODO
+                buf.copy_from_slice(&0u32.to_le_bytes());
+                Ok(4)
+            }
+            X86CoreRegId::St(idx) => {
+                let _value = cpu.fpu.st[idx as usize];
+                // TODO convert to f80
+                buf.copy_from_slice(&[0u8; 10]);
+                Ok(10)
+            }
+            X86CoreRegId::Fpu(_reg_id) => {
+                // TODO
+                buf.copy_from_slice(&0u32.to_le_bytes());
+                Ok(4)
+            }
+            X86CoreRegId::Xmm(_idx) => {
+                // TODO
+                buf.copy_from_slice(&0u128.to_le_bytes());
+                Ok(16)
+            }
+            X86CoreRegId::Mxcsr => {
+                // TODO
+                buf.copy_from_slice(&0u32.to_le_bytes());
+                Ok(4)
+            }
+            _ => {
+                log::warn!("read_register: unsupported register {:?}", reg_id);
+                Ok(0)
+            }
+        }
+    }
+
+    fn write_register(
+        &mut self,
+        _tid: (),
+        reg_id: <Self::Arch as Arch>::RegId,
+        val: &[u8],
+    ) -> TargetResult<(), Self> {
+        use gdbstub_arch::x86::reg::id::X86CoreRegId;
+        let cpu = self.machine.emu.x86.cpu_mut();
+        fn reg_write_u32(
+            cpu: &mut x86::CPU,
+            val: &[u8],
+            reg: x86::Register,
+        ) -> TargetResult<(), MachineTarget> {
+            let value = u32::from_le_bytes(val.try_into().unwrap());
+            cpu.regs.set32(reg, value);
+            Ok(())
+        }
+        match reg_id {
+            X86CoreRegId::Eax => reg_write_u32(cpu, val, x86::Register::EAX),
+            X86CoreRegId::Ecx => reg_write_u32(cpu, val, x86::Register::ECX),
+            X86CoreRegId::Edx => reg_write_u32(cpu, val, x86::Register::EDX),
+            X86CoreRegId::Ebx => reg_write_u32(cpu, val, x86::Register::EBX),
+            X86CoreRegId::Esp => reg_write_u32(cpu, val, x86::Register::ESP),
+            X86CoreRegId::Ebp => reg_write_u32(cpu, val, x86::Register::EBP),
+            X86CoreRegId::Esi => reg_write_u32(cpu, val, x86::Register::ESI),
+            X86CoreRegId::Edi => reg_write_u32(cpu, val, x86::Register::EDI),
+            X86CoreRegId::Eip => {
+                cpu.regs.eip = u32::from_le_bytes(val.try_into().unwrap());
+                Ok(())
+            }
+            X86CoreRegId::Eflags => {
+                cpu.flags =
+                    x86::Flags::from_bits_truncate(u32::from_le_bytes(val.try_into().unwrap()));
+                Ok(())
+            }
+            X86CoreRegId::Segment(_reg_id) => {
+                // TODO
+                Ok(())
+            }
+            X86CoreRegId::St(_idx) => {
+                // TODO
+                Ok(())
+            }
+            X86CoreRegId::Fpu(_reg_id) => {
+                // TODO
+                Ok(())
+            }
+            X86CoreRegId::Xmm(_idx) => {
+                // TODO
+                Ok(())
+            }
+            X86CoreRegId::Mxcsr => {
+                // TODO
+                Ok(())
+            }
+            _ => {
+                log::warn!("write_register: unsupported register {:?}", reg_id);
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(feature = "x86-unicorn")]
+const ST_REGS: [unicorn_engine::RegisterX86; 8] = [
+    unicorn_engine::RegisterX86::ST0,
+    unicorn_engine::RegisterX86::ST1,
+    unicorn_engine::RegisterX86::ST2,
+    unicorn_engine::RegisterX86::ST3,
+    unicorn_engine::RegisterX86::ST4,
+    unicorn_engine::RegisterX86::ST5,
+    unicorn_engine::RegisterX86::ST6,
+    unicorn_engine::RegisterX86::ST7,
+];
+
+#[cfg(feature = "x86-unicorn")]
+const XMM_REGS: [unicorn_engine::RegisterX86; 8] = [
+    unicorn_engine::RegisterX86::XMM0,
+    unicorn_engine::RegisterX86::XMM1,
+    unicorn_engine::RegisterX86::XMM2,
+    unicorn_engine::RegisterX86::XMM3,
+    unicorn_engine::RegisterX86::XMM4,
+    unicorn_engine::RegisterX86::XMM5,
+    unicorn_engine::RegisterX86::XMM6,
+    unicorn_engine::RegisterX86::XMM7,
+];
+
+#[cfg(feature = "x86-unicorn")]
+impl SingleThreadBase for MachineTarget {
+    fn read_registers(
+        &mut self,
+        regs: &mut <Self::Arch as Arch>::Registers,
+    ) -> TargetResult<(), Self> {
+        let cpu = &self.machine.emu.unicorn;
+        regs.eax = cpu.reg_read(unicorn_engine::RegisterX86::EAX).unwrap() as u32;
+        regs.ecx = cpu.reg_read(unicorn_engine::RegisterX86::ECX).unwrap() as u32;
+        regs.edx = cpu.reg_read(unicorn_engine::RegisterX86::EDX).unwrap() as u32;
+        regs.ebx = cpu.reg_read(unicorn_engine::RegisterX86::EBX).unwrap() as u32;
+        regs.esp = cpu.reg_read(unicorn_engine::RegisterX86::ESP).unwrap() as u32;
+        regs.ebp = cpu.reg_read(unicorn_engine::RegisterX86::EBP).unwrap() as u32;
+        regs.esi = cpu.reg_read(unicorn_engine::RegisterX86::ESI).unwrap() as u32;
+        regs.edi = cpu.reg_read(unicorn_engine::RegisterX86::EDI).unwrap() as u32;
+        regs.eip = cpu.reg_read(unicorn_engine::RegisterX86::EIP).unwrap() as u32;
+        regs.eflags = cpu.reg_read(unicorn_engine::RegisterX86::EFLAGS).unwrap() as u32;
+        regs.segments.cs = cpu.reg_read(unicorn_engine::RegisterX86::CS).unwrap() as u32;
+        regs.segments.ss = cpu.reg_read(unicorn_engine::RegisterX86::SS).unwrap() as u32;
+        regs.segments.ds = cpu.reg_read(unicorn_engine::RegisterX86::DS).unwrap() as u32;
+        regs.segments.es = cpu.reg_read(unicorn_engine::RegisterX86::ES).unwrap() as u32;
+        regs.segments.fs = cpu.reg_read(unicorn_engine::RegisterX86::FS).unwrap() as u32;
+        regs.segments.gs = cpu.reg_read(unicorn_engine::RegisterX86::GS).unwrap() as u32;
+        for (idx, reg) in ST_REGS.iter().cloned().enumerate() {
+            regs.st[idx] = cpu.reg_read_long(reg).unwrap().as_ref().try_into().unwrap();
+        }
+        // TODO regs.fpu
+        for (idx, reg) in XMM_REGS.iter().cloned().enumerate() {
+            regs.xmm[idx] =
+                u128::from_le_bytes(cpu.reg_read_long(reg).unwrap().as_ref().try_into().unwrap());
+        }
+        regs.mxcsr = cpu.reg_read(unicorn_engine::RegisterX86::MXCSR).unwrap() as u32;
+        Ok(())
+    }
+
+    fn write_registers(
+        &mut self,
+        regs: &<Self::Arch as Arch>::Registers,
+    ) -> TargetResult<(), Self> {
+        let cpu = &mut self.machine.emu.unicorn;
+        cpu.reg_write(unicorn_engine::RegisterX86::EAX, regs.eax as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::ECX, regs.ecx as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::EDX, regs.edx as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::EBX, regs.ebx as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::ESP, regs.esp as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::EBP, regs.ebp as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::ESI, regs.esi as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::EDI, regs.edi as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::EIP, regs.eip as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::EFLAGS, regs.eflags as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::CS, regs.segments.cs as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::SS, regs.segments.ss as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::DS, regs.segments.ds as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::ES, regs.segments.es as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::FS, regs.segments.fs as u64)
+            .unwrap();
+        cpu.reg_write(unicorn_engine::RegisterX86::GS, regs.segments.gs as u64)
+            .unwrap();
+        for (idx, reg) in ST_REGS.iter().cloned().enumerate() {
+            cpu.reg_write_long(reg, &regs.st[idx]).unwrap();
+        }
+        // TODO regs.fpu
+        for (idx, reg) in XMM_REGS.iter().cloned().enumerate() {
+            cpu.reg_write_long(reg, &regs.xmm[idx].to_le_bytes())
+                .unwrap();
+        }
+        cpu.reg_write(unicorn_engine::RegisterX86::MXCSR, regs.mxcsr as u64)
+            .unwrap();
+        Ok(())
+    }
+
+    fn support_single_register_access(&mut self) -> Option<SingleRegisterAccessOps<'_, (), Self>> {
+        Some(self)
+    }
+
+    fn read_addrs(
+        &mut self,
+        start_addr: <Self::Arch as Arch>::Usize,
+        data: &mut [u8],
+    ) -> TargetResult<usize, Self> {
+        let mem = self.machine.mem();
+        let slice = if start_addr > mem.len() {
+            return Ok(0);
+        } else if start_addr + data.len() as u32 > mem.len() {
+            mem.sub(start_addr, mem.len() - start_addr).as_slice_todo()
+        } else {
+            mem.sub(start_addr, data.len() as u32).as_slice_todo()
+        };
+        data[..slice.len()].copy_from_slice(slice);
+        Ok(slice.len())
+    }
+
+    fn write_addrs(
+        &mut self,
+        start_addr: <Self::Arch as Arch>::Usize,
+        data: &[u8],
+    ) -> TargetResult<(), Self> {
+        self.machine
+            .mem()
+            .sub32_mut(start_addr, data.len() as u32)
+            .copy_from_slice(data);
+        Ok(())
+    }
+
+    fn support_resume(&mut self) -> Option<SingleThreadResumeOps<'_, Self>> {
+        Some(self)
+    }
+}
+
+#[cfg(feature = "x86-unicorn")]
+impl SingleRegisterAccess<()> for MachineTarget {
+    fn read_register(
+        &mut self,
+        _tid: (),
+        reg_id: <Self::Arch as Arch>::RegId,
+        buf: &mut [u8],
+    ) -> TargetResult<usize, Self> {
+        use gdbstub_arch::x86::reg::id::{X86CoreRegId, X86SegmentRegId};
+        let cpu = &self.machine.emu.unicorn;
+        fn reg_read_u32(
+            cpu: &unicorn_engine::Unicorn<()>,
+            buf: &mut [u8],
+            reg: unicorn_engine::RegisterX86,
+        ) -> TargetResult<usize, MachineTarget> {
+            let value = cpu.reg_read(reg).unwrap() as u32;
+            buf.copy_from_slice(&value.to_le_bytes());
+            Ok(4)
+        }
+        match reg_id {
+            X86CoreRegId::Eax => reg_read_u32(cpu, buf, unicorn_engine::RegisterX86::EAX),
+            X86CoreRegId::Ecx => reg_read_u32(cpu, buf, unicorn_engine::RegisterX86::ECX),
+            X86CoreRegId::Edx => reg_read_u32(cpu, buf, unicorn_engine::RegisterX86::EDX),
+            X86CoreRegId::Ebx => reg_read_u32(cpu, buf, unicorn_engine::RegisterX86::EBX),
+            X86CoreRegId::Esp => reg_read_u32(cpu, buf, unicorn_engine::RegisterX86::ESP),
+            X86CoreRegId::Ebp => reg_read_u32(cpu, buf, unicorn_engine::RegisterX86::EBP),
+            X86CoreRegId::Esi => reg_read_u32(cpu, buf, unicorn_engine::RegisterX86::ESI),
+            X86CoreRegId::Edi => reg_read_u32(cpu, buf, unicorn_engine::RegisterX86::EDI),
+            X86CoreRegId::Eip => reg_read_u32(cpu, buf, unicorn_engine::RegisterX86::EIP),
+            X86CoreRegId::Eflags => reg_read_u32(cpu, buf, unicorn_engine::RegisterX86::EFLAGS),
+            X86CoreRegId::Segment(reg_id) => reg_read_u32(
+                cpu,
+                buf,
+                match reg_id {
+                    X86SegmentRegId::CS => unicorn_engine::RegisterX86::CS,
+                    X86SegmentRegId::SS => unicorn_engine::RegisterX86::SS,
+                    X86SegmentRegId::DS => unicorn_engine::RegisterX86::DS,
+                    X86SegmentRegId::ES => unicorn_engine::RegisterX86::ES,
+                    X86SegmentRegId::FS => unicorn_engine::RegisterX86::FS,
+                    X86SegmentRegId::GS => unicorn_engine::RegisterX86::GS,
+                },
+            ),
+            X86CoreRegId::St(idx) => {
+                let value = cpu.reg_read_long(ST_REGS[idx as usize]).unwrap();
+                buf.copy_from_slice(value.as_ref());
+                Ok(10)
+            }
+            X86CoreRegId::Fpu(_reg_id) => {
+                // TODO
+                buf.copy_from_slice(&0u32.to_le_bytes());
+                Ok(4)
+            }
+            X86CoreRegId::Xmm(idx) => {
+                let value = cpu.reg_read_long(XMM_REGS[idx as usize]).unwrap();
+                buf.copy_from_slice(value.as_ref());
+                Ok(16)
+            }
+            X86CoreRegId::Mxcsr => reg_read_u32(cpu, buf, unicorn_engine::RegisterX86::MXCSR),
+            _ => {
+                log::warn!("read_register: unsupported register {:?}", reg_id);
+                Ok(0)
+            }
+        }
+    }
+
+    fn write_register(
+        &mut self,
+        _tid: (),
+        reg_id: <Self::Arch as Arch>::RegId,
+        val: &[u8],
+    ) -> TargetResult<(), Self> {
+        use gdbstub_arch::x86::reg::id::{X86CoreRegId, X86SegmentRegId};
+        let cpu = &mut self.machine.emu.unicorn;
+        fn reg_write_u32(
+            cpu: &mut unicorn_engine::Unicorn<()>,
+            reg: unicorn_engine::RegisterX86,
+            val: &[u8],
+        ) -> TargetResult<(), MachineTarget> {
+            let value = u32::from_le_bytes(val.try_into().unwrap());
+            cpu.reg_write(reg, value as u64).unwrap();
+            Ok(())
+        }
+        match reg_id {
+            X86CoreRegId::Eax => reg_write_u32(cpu, unicorn_engine::RegisterX86::EAX, val),
+            X86CoreRegId::Ecx => reg_write_u32(cpu, unicorn_engine::RegisterX86::ECX, val),
+            X86CoreRegId::Edx => reg_write_u32(cpu, unicorn_engine::RegisterX86::EDX, val),
+            X86CoreRegId::Ebx => reg_write_u32(cpu, unicorn_engine::RegisterX86::EBX, val),
+            X86CoreRegId::Esp => reg_write_u32(cpu, unicorn_engine::RegisterX86::ESP, val),
+            X86CoreRegId::Ebp => reg_write_u32(cpu, unicorn_engine::RegisterX86::EBP, val),
+            X86CoreRegId::Esi => reg_write_u32(cpu, unicorn_engine::RegisterX86::ESI, val),
+            X86CoreRegId::Edi => reg_write_u32(cpu, unicorn_engine::RegisterX86::EDI, val),
+            X86CoreRegId::Eip => reg_write_u32(cpu, unicorn_engine::RegisterX86::EIP, val),
+            X86CoreRegId::Eflags => reg_write_u32(cpu, unicorn_engine::RegisterX86::EFLAGS, val),
+            X86CoreRegId::Segment(reg_id) => reg_write_u32(
+                cpu,
+                match reg_id {
+                    X86SegmentRegId::CS => unicorn_engine::RegisterX86::CS,
+                    X86SegmentRegId::SS => unicorn_engine::RegisterX86::SS,
+                    X86SegmentRegId::DS => unicorn_engine::RegisterX86::DS,
+                    X86SegmentRegId::ES => unicorn_engine::RegisterX86::ES,
+                    X86SegmentRegId::FS => unicorn_engine::RegisterX86::FS,
+                    X86SegmentRegId::GS => unicorn_engine::RegisterX86::GS,
+                },
+                val,
+            ),
+            X86CoreRegId::St(idx) => {
+                cpu.reg_write_long(ST_REGS[idx as usize], val).unwrap();
+                Ok(())
+            }
+            X86CoreRegId::Fpu(_reg_id) => {
+                // TODO
+                Ok(())
+            }
+            X86CoreRegId::Xmm(idx) => {
+                cpu.reg_write_long(XMM_REGS[idx as usize], val).unwrap();
+                Ok(())
+            }
+            X86CoreRegId::Mxcsr => reg_write_u32(cpu, unicorn_engine::RegisterX86::MXCSR, val),
+            _ => {
+                log::warn!("write_register: unsupported register {:?}", reg_id);
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Breakpoints for MachineTarget {
+    fn support_sw_breakpoint(&mut self) -> Option<SwBreakpointOps<'_, Self>> {
+        Some(self)
+    }
+}
+
+impl SwBreakpoint for MachineTarget {
+    fn add_sw_breakpoint(
+        &mut self,
+        addr: <Self::Arch as Arch>::Usize,
+        kind: <Self::Arch as Arch>::BreakpointKind,
+    ) -> TargetResult<bool, Self> {
+        log::info!("add_sw_breakpoint: {:#x} {}", addr, kind);
+        Ok(self.machine.add_breakpoint(addr))
+    }
+
+    fn remove_sw_breakpoint(
+        &mut self,
+        addr: <Self::Arch as Arch>::Usize,
+        kind: <Self::Arch as Arch>::BreakpointKind,
+    ) -> TargetResult<bool, Self> {
+        log::info!("remove_sw_breakpoint: {:#x} {}", addr, kind);
+        Ok(self.machine.clear_breakpoint(addr))
+    }
+}
+
+impl ExecFile for MachineTarget {
+    fn get_exec_file(
+        &self,
+        pid: Option<Pid>,
+        offset: u64,
+        length: usize,
+        buf: &mut [u8],
+    ) -> TargetResult<usize, Self> {
+        if !matches!(pid, None | Some(Pid::MIN)) {
+            return Err(TargetError::Io(std::io::Error::new(
+                ErrorKind::Other,
+                "get_exec_file: pid is not supported",
+            )));
+        }
+        let path = self.machine.exe_path.as_os_str().as_encoded_bytes();
+        if offset >= path.len() as u64 {
+            return Ok(0);
+        }
+        let end = (offset + length as u64).min(path.len() as u64);
+        let slice = &path[offset as usize..end as usize];
+        buf[..slice.len()].copy_from_slice(slice);
+        Ok(slice.len())
+    }
+}
+
+impl HostIo for MachineTarget {
+    fn support_open(&mut self) -> Option<HostIoOpenOps<'_, Self>> {
+        Some(self)
+    }
+
+    fn support_close(&mut self) -> Option<HostIoCloseOps<'_, Self>> {
+        Some(self)
+    }
+
+    fn support_pread(&mut self) -> Option<HostIoPreadOps<'_, Self>> {
+        Some(self)
+    }
+
+    fn support_pwrite(&mut self) -> Option<HostIoPwriteOps<'_, Self>> {
+        // omitting write support for now
+        None
+    }
+}
+
+impl HostIoOpen for MachineTarget {
+    fn open(
+        &mut self,
+        filename: &[u8],
+        flags: HostIoOpenFlags,
+        mode: HostIoOpenMode,
+    ) -> HostIoResult<u32, Self> {
+        let path = String::from_utf8_lossy(filename);
+        let mut options = std::fs::OpenOptions::new();
+        let rw = flags.contains(HostIoOpenFlags::O_RDWR);
+        options
+            .read(rw || flags.contains(HostIoOpenFlags::O_RDONLY))
+            .write(rw || flags.contains(HostIoOpenFlags::O_WRONLY))
+            .create(flags.contains(HostIoOpenFlags::O_CREAT))
+            .append(flags.contains(HostIoOpenFlags::O_APPEND))
+            .truncate(flags.contains(HostIoOpenFlags::O_TRUNC));
+        let _ = mode; // TODO
+        let file = match options.open::<&str>(path.as_ref()) {
+            Ok(file) => file,
+            Err(err) => {
+                return Err(HostIoError::from(err));
+            }
+        };
+        // TODO windows
+        use std::os::fd::IntoRawFd;
+        let fd = file.into_raw_fd() as u32;
+        Ok(fd)
+    }
+}
+
+impl HostIoClose for MachineTarget {
+    fn close(&mut self, fd: u32) -> HostIoResult<(), Self> {
+        // TODO windows
+        use std::os::unix::io::FromRawFd;
+        let file = unsafe { std::fs::File::from_raw_fd(fd as i32) };
+        file.sync_all().map_err(|e| HostIoError::from(e))
+    }
+}
+
+impl HostIoPread for MachineTarget {
+    fn pread(
+        &mut self,
+        fd: u32,
+        count: usize,
+        offset: u64,
+        buf: &mut [u8],
+    ) -> HostIoResult<usize, Self> {
+        // TODO windows
+        use std::os::unix::{fs::FileExt, io::FromRawFd};
+        let file = unsafe { std::fs::File::from_raw_fd(fd as i32) };
+        let end = count.min(buf.len());
+        file.read_at(&mut buf[..end], offset)
+            .map_err(|e| HostIoError::from(e))
+    }
+}
+
+impl SingleThreadResume for MachineTarget {
+    fn resume(&mut self, signal: Option<Signal>) -> Result<(), Self::Error> {
+        let _ = signal;
+        self.action = Some(MachineTargetAction::Resume);
+        Ok(())
+    }
+
+    fn support_single_step(&mut self) -> Option<SingleThreadSingleStepOps<'_, Self>> {
+        Some(self)
+    }
+
+    fn support_range_step(&mut self) -> Option<SingleThreadRangeSteppingOps<'_, Self>> {
+        None // TODO
+    }
+}
+
+impl SingleThreadSingleStep for MachineTarget {
+    fn step(&mut self, signal: Option<Signal>) -> Result<(), Self::Error> {
+        let _ = signal;
+        self.action = Some(MachineTargetAction::SingleStep);
+        Ok(())
+    }
+}
+
+fn wait_for_gdb_connection(port: u16) -> std::io::Result<std::net::TcpStream> {
+    let sockaddr = format!("localhost:{}", port);
+    log::info!("Waiting for a GDB connection on {:?}...", sockaddr);
+    let sock = std::net::TcpListener::bind(sockaddr)?;
+    let (stream, addr) = sock.accept()?;
+    log::info!("Debugger connected from {}", addr);
+    Ok(stream)
+}
+
+pub type StateMachine<'a> = GdbStubStateMachine<'a, MachineTarget, std::net::TcpStream>;
+
+pub fn run<'a>(target: &mut MachineTarget) -> anyhow::Result<StateMachine<'a>> {
+    let connection: std::net::TcpStream = wait_for_gdb_connection(9001)?;
+    let debugger = GdbStub::new(connection);
+    Ok(debugger.run_state_machine(target)?)
+}
+
+pub trait DebuggerExt {
+    /// Poll the socket for incoming data and process it, optionally returning an action.
+    fn poll(&mut self, target: &mut MachineTarget) -> anyhow::Result<Option<MachineTargetAction>>;
+    /// Notify the debugger that the machine has completed a single or range step.
+    fn done_step(&mut self, target: &mut MachineTarget) -> anyhow::Result<()>;
+    /// Notify the debugger that the machine has encountered an error.
+    fn machine_error(&mut self, target: &mut MachineTarget, signal: u8) -> anyhow::Result<()>;
+    /// Notify the debugger that the machine has hit a breakpoint.
+    fn breakpoint(&mut self, target: &mut MachineTarget) -> anyhow::Result<()>;
+    /// Notify the debugger that the machine is currently stopped.
+    /// Will block until new data is available to avoid busy-waiting.
+    fn stopped(&mut self, target: &mut MachineTarget) -> anyhow::Result<()>;
+}
+
+impl DebuggerExt for Option<StateMachine<'_>> {
+    fn poll(&mut self, target: &mut MachineTarget) -> anyhow::Result<Option<MachineTargetAction>> {
+        if let Some(state) = self.take() {
+            *self = match state {
+                GdbStubStateMachine::Idle(mut inner) => {
+                    use gdbstub::conn::ConnectionExt;
+                    let conn = inner.borrow_conn();
+                    Some(if conn.peek()?.is_some() {
+                        let byte = conn.read()?;
+                        inner.incoming_data(target, byte)?
+                    } else {
+                        GdbStubStateMachine::Idle(inner)
+                    })
+                }
+                GdbStubStateMachine::Running(mut inner) => {
+                    use gdbstub::conn::ConnectionExt;
+                    let conn = inner.borrow_conn();
+                    Some(if conn.peek()?.is_some() {
+                        let byte = conn.read()?;
+                        inner.incoming_data(target, byte)?
+                    } else {
+                        GdbStubStateMachine::Running(inner)
+                    })
+                }
+                GdbStubStateMachine::CtrlCInterrupt(inner) => {
+                    target.action = Some(MachineTargetAction::Stop);
+                    Some(
+                        inner
+                            .interrupt_handled(target, Some(SingleThreadStopReason::SwBreak(())))?,
+                    )
+                }
+                GdbStubStateMachine::Disconnected(_inner) => {
+                    log::info!("debugger disconnected");
+                    None
+                }
+            };
+        }
+        Ok(target.action.take())
+    }
+
+    fn done_step(&mut self, target: &mut MachineTarget) -> anyhow::Result<()> {
+        if let Some(state) = self.take() {
+            *self = match state {
+                GdbStubStateMachine::Running(inner) => {
+                    Some(inner.report_stop(target, BaseStopReason::<(), u32>::DoneStep)?)
+                }
+                state => Some(state),
+            }
+        }
+        Ok(())
+    }
+
+    fn machine_error(&mut self, target: &mut MachineTarget, signal: u8) -> anyhow::Result<()> {
+        if let Some(state) = self.take() {
+            *self = match state {
+                GdbStubStateMachine::Running(inner) => Some(
+                    inner.report_stop(target, BaseStopReason::<(), u32>::Signal(Signal(signal)))?,
+                ),
+                state => Some(state),
+            }
+        }
+        Ok(())
+    }
+
+    fn breakpoint(&mut self, target: &mut MachineTarget) -> anyhow::Result<()> {
+        if let Some(state) = self.take() {
+            *self = match state {
+                GdbStubStateMachine::Running(inner) => {
+                    Some(inner.report_stop(target, BaseStopReason::SwBreak(()))?)
+                }
+                state => Some(state),
+            }
+        }
+        Ok(())
+    }
+
+    fn stopped(&mut self, target: &mut MachineTarget) -> anyhow::Result<()> {
+        if let Some(state) = self.take() {
+            *self = match state {
+                GdbStubStateMachine::Running(inner) => {
+                    Some(inner.report_stop(target, BaseStopReason::<(), u32>::DoneStep)?)
+                }
+                GdbStubStateMachine::Idle(mut inner) => {
+                    // Both program and debugger are stopped. Read a byte synchronously
+                    // from the connection to avoid busy-waiting.
+                    use gdbstub::conn::ConnectionExt;
+                    let byte = inner.borrow_conn().read()?;
+                    Some(inner.incoming_data(target, byte)?)
+                }
+                state => Some(state),
+            }
+        }
+        Ok(())
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,4 @@
+mod debugger;
 mod host;
 mod logging;
 
@@ -10,23 +11,11 @@ mod sdl;
 mod resv32;
 
 use anyhow::anyhow;
+use debugger::{DebuggerExt, MachineTarget, MachineTargetAction};
 use std::borrow::Cow;
 use std::process::ExitCode;
 use win32::winapi::types::win32_error_str;
 use win32::Host;
-
-#[cfg(feature = "x86-emu")]
-fn dump_asm(machine: &win32::Machine, count: usize) {
-    let instrs = win32::disassemble(machine.mem(), machine.emu.x86.cpu().regs.eip, count);
-
-    for instr in instrs {
-        print!("{:08x} {:10} ", instr.addr, instr.bytes);
-        for part in &instr.code {
-            print!("{}", part.text);
-        }
-        println!();
-    }
-}
 
 #[derive(argh::FromArgs)]
 /// win32 emulator.
@@ -39,19 +28,10 @@ struct Args {
     #[argh(option)]
     win32_trace: Option<String>,
 
-    /// log CPU state upon each new basic block
+    /// enable GDB stub
     #[argh(switch)]
-    #[cfg(feature = "x86-emu")]
-    trace_blocks: bool,
-
-    /// log CPU state first time each point reached
-    #[argh(option, from_str_fn(parse_trace_points))]
-    trace_points: Option<std::collections::VecDeque<u32>>,
-
-    /// load snapshot from file
-    #[cfg(feature = "x86-emu")]
-    #[argh(option)]
-    snapshot: Option<String>,
+    #[cfg(any(feature = "x86-emu", feature = "x86-unicorn"))]
+    gdb_stub: bool,
 
     /// enable debug logging
     #[argh(switch)]
@@ -101,32 +81,6 @@ fn print_trace(machine: &win32::Machine) {
     println!("@{eip:x}\n  eax:{eax:x} ebx:{ebx:x} ecx:{ecx:x} edx:{edx:x} esi:{esi:x} edi:{edi:x} esp:{esp:x} ebp:{ebp:x} st_top:{st_top}");
 }
 
-fn parse_trace_points(param: &str) -> Result<std::collections::VecDeque<u32>, String> {
-    let mut trace_points = std::collections::VecDeque::new();
-    for addr in param.split(",") {
-        if addr.is_empty() {
-            continue;
-        }
-        let addr = u32::from_str_radix(addr, 16).map_err(|_| format!("bad addr {addr:?}"))?;
-        trace_points.push_back(addr);
-    }
-    Ok(trace_points)
-}
-
-#[allow(unused)]
-static mut SNAPSHOT_REQUESTED: bool = false;
-
-#[cfg(target_family = "unix")]
-fn install_sigusr1_handler() {
-    unsafe extern "C" fn sigusr1(_sig: usize) {
-        SNAPSHOT_REQUESTED = true;
-    }
-    let ret = unsafe { libc::signal(libc::SIGUSR1, sigusr1 as *const fn(usize) as usize) };
-    if ret != 0 {
-        log::error!("failed to install signal handler for snapshot");
-    }
-}
-
 fn main() -> anyhow::Result<ExitCode> {
     #[cfg(feature = "x86-64")]
     unsafe {
@@ -150,7 +104,8 @@ fn main() -> anyhow::Result<ExitCode> {
         .cmdline
         .first()
         .ok_or_else(|| anyhow!("missing command line"))?;
-    let buf = std::fs::read(exe).map_err(|err| anyhow!("{}: {}", exe, err))?;
+    let exe = std::fs::canonicalize(exe).map_err(|err| anyhow!("{}: {}", exe, err))?;
+    let buf = std::fs::read(&exe).map_err(|err| anyhow!("{}: {}", exe.display(), err))?;
     let host = host::new_host();
 
     let mut cmdline = args.cmdline.clone();
@@ -170,118 +125,117 @@ fn main() -> anyhow::Result<ExitCode> {
     let mut machine = win32::Machine::new(Box::new(host.clone()), cmdline);
 
     let addrs = machine
-        .load_exe(&buf, exe, None)
-        .map_err(|err| anyhow!("loading {}: {}", exe, err))?;
-
-    #[cfg(target_family = "unix")]
-    install_sigusr1_handler();
+        .load_exe(&buf, &exe, None)
+        .map_err(|err| anyhow!("loading {}: {}", exe.display(), err))?;
+    _ = addrs;
 
     #[cfg(feature = "x86-64")]
-    {
+    let exit_code = {
         assert!(args.trace_points.is_none());
         unsafe {
             let ptr: *mut win32::Machine = &mut machine;
             machine.emu.shims.set_machine_hack(ptr, addrs.stack_pointer);
             machine.jump_to_entry_point(addrs.entry_point);
         }
-    }
+        ExitCode::SUCCESS
+    };
 
     #[cfg(feature = "x86-emu")]
-    {
-        _ = addrs;
+    let start = std::time::Instant::now();
 
-        if let Some(snap) = args.snapshot {
-            let bytes = std::fs::read(snap).unwrap();
-            machine.load_snapshot(&bytes);
-        }
-
-        let start = std::time::Instant::now();
-        if args.trace_blocks {
-            let mut seen_blocks = std::collections::HashSet::new();
-            while machine.run() {
-                let regs = &machine.emu.x86.cpu().regs;
-                if regs.eip & 0xFFFF_0000 == 0xF1A7_0000 {
-                    continue;
-                }
-                if seen_blocks.contains(&regs.eip) {
-                    continue;
-                }
-                print_trace(&machine);
-                seen_blocks.insert(regs.eip);
-            }
-        } else if let Some(mut trace_points) = args.trace_points {
-            while let Some(next_trace) = trace_points.pop_front() {
-                machine.add_breakpoint(next_trace);
-                loop {
-                    // Ignore errors here because we will hit breakpoints.
-                    machine.run();
-                    if machine.emu.x86.cpu().regs.eip == next_trace {
-                        break;
-                    }
-                }
-                machine.clear_breakpoint(next_trace);
-
-                print_trace(&machine);
-            }
+    #[cfg(any(feature = "x86-emu", feature = "x86-unicorn"))]
+    let exit_code = {
+        let mut target = MachineTarget::new(machine);
+        let mut debugger = if args.gdb_stub {
+            Some(debugger::run(&mut target)?)
         } else {
-            while machine.run() {
-                unsafe {
-                    if SNAPSHOT_REQUESTED {
-                        let buf = machine.snapshot();
-                        let path = "snapshot";
-                        std::fs::write(path, buf).unwrap();
-                        log::info!("wrote snapshot to {path:?}");
-                        SNAPSHOT_REQUESTED = false;
+            None
+        };
+        enum MachineState {
+            Running,
+            Stopped,
+        }
+        let mut state = if debugger.is_some() {
+            MachineState::Stopped
+        } else {
+            MachineState::Running
+        };
+        let exit_code = loop {
+            let mut instruction_count = 0; // used to step a single instruction or range
+            match debugger.poll(&mut target)? {
+                Some(MachineTargetAction::Stop) => {
+                    state = MachineState::Stopped;
+                }
+                Some(MachineTargetAction::Resume) => {
+                    state = MachineState::Running;
+                }
+                Some(MachineTargetAction::SingleStep) => {
+                    instruction_count = 1;
+                    state = MachineState::Running;
+                }
+                None => {}
+            }
+            state = match state {
+                MachineState::Running => {
+                    match target.machine.run(instruction_count) {
+                        win32::StopReason::None => {
+                            if instruction_count > 0 {
+                                debugger.done_step(&mut target)?;
+                                MachineState::Stopped
+                            } else {
+                                MachineState::Running
+                            }
+                        }
+                        win32::StopReason::Error {
+                            message,
+                            signal,
+                            eip,
+                        } => {
+                            log::error!("Machine error @ {eip:x}: {message} (signal {signal})");
+                            print_trace(&target.machine);
+                            debugger.machine_error(&mut target, signal)?;
+                            MachineState::Stopped
+                        }
+                        win32::StopReason::Exit { code } => {
+                            break ExitCode::from(code.try_into().unwrap_or(u8::MAX));
+                        }
+                        win32::StopReason::Breakpoint { eip } => {
+                            log::info!("Breakpoint hit @ {eip:x}");
+                            debugger.breakpoint(&mut target)?;
+                            MachineState::Stopped
+                        }
+                        win32::StopReason::ShimCall(shim) => {
+                            // log::info!("Shim call {}", shim.name);
+                            target.machine.call_shim(shim);
+                            // TODO: what if we were single stepping?
+                            MachineState::Running
+                        }
                     }
                 }
+                MachineState::Stopped => {
+                    debugger.stopped(&mut target)?;
+                    MachineState::Stopped
+                }
+            };
+        };
+
+        #[cfg(feature = "x86-emu")]
+        {
+            let millis = start.elapsed().as_millis() as usize;
+            if millis > 0 {
+                eprintln!(
+                    "{} instrs in {} ms: {}m/s",
+                    target.machine.emu.x86.instr_count,
+                    millis,
+                    (target.machine.emu.x86.instr_count / millis) / 1000
+                );
+                eprintln!("icache: {}", target.machine.emu.x86.icache.stats());
             }
         }
 
-        match &machine.emu.x86.cpu().state {
-            x86::CPUState::Error(error) => {
-                log::error!("{:?}", error);
-                dump_asm(&machine, 5);
-            }
-            x86::CPUState::Exit(_) => {}
-            x86::CPUState::Blocked(_) => unreachable!(),
-            x86::CPUState::Running => unreachable!(),
-            x86::CPUState::DebugBreak => todo!(),
-        }
+        exit_code
+    };
 
-        let millis = start.elapsed().as_millis() as usize;
-        if millis > 0 {
-            eprintln!(
-                "{} instrs in {} ms: {}m/s",
-                machine.emu.x86.instr_count,
-                millis,
-                (machine.emu.x86.instr_count / millis) / 1000
-            );
-            eprintln!("icache: {}", machine.emu.x86.icache.stats());
-        }
-    }
-
-    #[cfg(feature = "x86-unicorn")]
-    {
-        let mut trace_points = args.trace_points.unwrap_or_default();
-        let mut eip = addrs.entry_point;
-        loop {
-            let end = trace_points.pop_front().unwrap_or(0);
-            win32::shims::unicorn_loop(&mut machine, eip, end);
-            if end == 0 {
-                break;
-            } else {
-                print_trace(&machine);
-                eip = end;
-            }
-        }
-    }
-
-    let exit_code = host
-        .0
-        .borrow()
-        .exit_code()
-        .map(|c| ExitCode::from(c.try_into().unwrap_or(u8::MAX)))
-        .unwrap_or(ExitCode::SUCCESS);
     Ok(exit_code)
 }
 

--- a/gdb-script
+++ b/gdb-script
@@ -1,0 +1,2 @@
+target remote localhost:9001
+set disassembly-flavor intel

--- a/lldb-script
+++ b/lldb-script
@@ -1,0 +1,3 @@
+log enable gdb-remote packets
+gdb-remote localhost:9001
+#target create exe/winapi/winapi.exe

--- a/win32/Cargo.toml
+++ b/win32/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0"
 bincode = "1.3.3"
 bitflags = "1.3.2"
 chrono = "0.4.38"
+futures = "0.3.30"
 num-derive = "0.3"
 num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/win32/derive/src/gen.rs
+++ b/win32/derive/src/gen.rs
@@ -35,48 +35,39 @@ pub fn fn_wrapper(module: TokenStream, dllexport: &DllExport) -> (TokenStream, T
         .iter()
         .map(|arg| arg.name)
         .collect::<Vec<_>>();
-    let body = if dllexport.func.sig.asyncness.is_some() {
-        quote! {
-        #fetch_args
-        #[cfg(feature = "x86-emu")]
-        {
-            // Yuck: we know Machine will outlive the future, but Rust doesn't.
-            // At least we managed to isolate the yuck to this point.
-            let m: *mut Machine = machine;
-            let result = async move {
-                use memory::Extensions;
-                let machine = unsafe { &mut *m };
-                let result = #module::#name(machine, #(#args),*).await;
-                let regs = &mut machine.emu.x86.cpu_mut().regs;
-                regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                *regs.get32_mut(x86::Register::ESP) += #stack_consumed + 4;
-                regs.set32(x86::Register::EAX, result.to_raw());
-            };
-            machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-            // async block will set up the stack and eip.
-            0
-        }
-        #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-        {
-            // In the non-emulated case, we synchronously evaluate the future.
-            let pin = std::pin::pin!(#module::#name(machine, #(#args),*));
-            crate::shims::call_sync(pin).to_raw()
-        }
-        }
+    let (func, body) = if dllexport.func.sig.asyncness.is_some() {
+        (
+            quote!(shims::Handler::Async(impls::#name)),
+            quote! {
+                #fetch_args
+                let machine: *mut Machine = machine;
+                Box::pin(async move {
+                    let machine = unsafe { &mut *machine };
+                    #module::#name(machine, #(#args),*).await.to_raw()
+                })
+            },
+        )
     } else {
-        quote! {
-            #fetch_args
-            #module::#name(machine, #(#args),*).to_raw()
-        }
+        (
+            quote!(shims::Handler::Sync(impls::#name)),
+            quote! {
+                #fetch_args
+                #module::#name(machine, #(#args),*).to_raw()
+            },
+        )
     };
 
+    let retn = if is_async {
+        quote!(std::pin::Pin<Box<dyn std::future::Future<Output = u32>>>)
+    } else {
+        quote!(u32)
+    };
     (
-        quote!(pub unsafe fn #name(machine: &mut Machine, esp: u32) -> u32 { #body }),
-        quote!(pub const #name: Shim = Shim {
+        quote!(pub unsafe fn #name(machine: &mut Machine, esp: u32) -> #retn { #body }),
+        quote!(pub const #name: shims::Shim = shims::Shim {
             name: #name_str,
-            func: impls::#name,
+            func: #func,
             stack_consumed: #stack_consumed,
-            is_async: #is_async,
         };),
     )
 }

--- a/win32/derive/src/lib.rs
+++ b/win32/derive/src/lib.rs
@@ -47,7 +47,7 @@ pub fn shims_from_x86(
 
     let shims_module: syn::ItemMod = syn::parse2::<syn::ItemMod>(quote! {
         pub mod shims {
-            use crate::shims::Shim;
+            use crate::shims;
             use super::impls;
             #(#shims)*
         }

--- a/win32/derive/src/main.rs
+++ b/win32/derive/src/main.rs
@@ -83,7 +83,7 @@ fn generate_shims_module(
             }
 
             mod shims {
-                use crate::shims::Shim;
+                use crate::shims;
                 use super::impls;
                 #(#shims)*
             }

--- a/win32/src/lib.rs
+++ b/win32/src/lib.rs
@@ -25,6 +25,7 @@ mod machine_unicorn;
 mod shims_unicorn;
 
 pub use host::*;
-pub use machine::Machine;
+pub use machine::{Machine, StopReason};
+pub use memory as mem;
 #[cfg(feature = "x86-emu")]
 pub use x86::debug::disassemble;

--- a/win32/src/machine.rs
+++ b/win32/src/machine.rs
@@ -1,5 +1,7 @@
+use crate::shims::Shim;
 use crate::{host, winapi};
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[cfg(feature = "x86-emu")]
 pub use crate::machine_emu::{Machine, MemImpl};
@@ -19,4 +21,21 @@ pub struct MachineX<Emu> {
     pub host: Box<dyn host::Host>,
     pub state: winapi::State,
     pub labels: HashMap<u32, String>,
+    pub exe_path: PathBuf,
+}
+
+pub enum StopReason {
+    None,
+    Breakpoint {
+        eip: u32,
+    },
+    ShimCall(&'static Shim),
+    Error {
+        message: String,
+        signal: u8,
+        eip: u32,
+    },
+    Exit {
+        code: u32,
+    },
 }

--- a/win32/src/machine_emu.rs
+++ b/win32/src/machine_emu.rs
@@ -1,12 +1,15 @@
+use crate::shims::Shim;
+use crate::shims_emu::handle_shim_call;
 use crate::{
     host,
     machine::{LoadedAddrs, MachineX},
     pe,
     shims_emu::Shims,
-    winapi,
+    winapi, StopReason,
 };
 use memory::{Extensions, Mem};
 use std::collections::HashMap;
+use std::path::Path;
 
 // This is really Box<u8>, just using Vec<u8> to use serde_bytes.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -34,11 +37,9 @@ impl BoxMem {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
 pub struct Emulator {
     pub x86: x86::X86,
     pub memory: BoxMem,
-    #[serde(skip)]
     pub shims: Shims,
 
     /// Places where we've patched out the instruction with an int3.
@@ -66,6 +67,7 @@ impl MachineX<Emulator> {
             host,
             state,
             labels: HashMap::new(),
+            exe_path: Default::default(),
         }
     }
 
@@ -87,10 +89,10 @@ impl MachineX<Emulator> {
     pub fn load_exe(
         &mut self,
         buf: &[u8],
-        filename: &str,
+        path: &Path,
         relocate: Option<Option<u32>>,
     ) -> anyhow::Result<LoadedAddrs> {
-        let exe = pe::load_exe(self, buf, filename, relocate)?;
+        let exe = pe::load_exe(self, buf, path, relocate)?;
 
         let stack_pointer = self.create_stack("stack".into(), exe.stack_size);
         let regs = &mut self.emu.x86.cpu_mut().regs;
@@ -111,17 +113,11 @@ impl MachineX<Emulator> {
         x86::ops::push(cpu, self.emu.memory.mem(), 0); // return address
         cpu.regs.eip = retrowin32_main;
 
+        self.exe_path = path.to_path_buf();
         Ok(LoadedAddrs {
             entry_point: exe.entry_point,
             stack_pointer,
         })
-    }
-
-    pub fn single_step(&mut self) {
-        if !crate::shims_emu::is_ip_at_shim_call(self.emu.x86.cpu().regs.eip) {
-            self.emu.x86.single_step_next_block(self.emu.memory.mem());
-        }
-        self.run();
     }
 
     pub fn unblock_all(&mut self) {
@@ -145,91 +141,118 @@ impl MachineX<Emulator> {
         }
     }
 
-    pub fn run(&mut self) -> bool {
+    pub fn run(&mut self, instruction_count: usize) -> StopReason {
         self.emu.x86.schedule();
+        let eip = self.emu.x86.cpu().regs.eip;
         match &self.emu.x86.cpu().state {
-            x86::CPUState::Running => self.execute_block(),
+            x86::CPUState::Running => self.execute_block(instruction_count),
             x86::CPUState::Blocked(wait) => {
                 let wait = *wait;
                 if self.host.block(wait) {
                     self.unblock();
-                } else {
-                    return false;
                 }
+                StopReason::None
             }
-            _ => return false,
+            x86::CPUState::DebugBreak => {
+                // resume execution after breakpoint
+                self.emu.x86.cpu_mut().state = x86::CPUState::Running;
+                self.execute_block(instruction_count)
+            }
+            x86::CPUState::Error(message) => StopReason::Error {
+                message: message.clone(),
+                signal: 11, // SIGSEGV, TODO?
+                eip,
+            },
+            x86::CPUState::Exit(_) => unreachable!(),
         }
-        true
     }
 
-    // Execute one basic block.  Returns false if we stopped early.
-    fn execute_block(&mut self) {
+    /// Execute one basic block or number of instructions.
+    pub fn execute_block(&mut self, instruction_count: usize) -> StopReason {
         debug_assert!(self.emu.x86.cpu().state.is_running());
         let eip = self.emu.x86.cpu().regs.eip;
         if crate::shims_emu::is_ip_at_shim_call(eip) {
             if self.emu.breakpoints.contains_key(&eip) {
-                self.emu.x86.cpu_mut().state = x86::CPUState::DebugBreak;
-                return;
+                return StopReason::Breakpoint { eip };
             }
-
-            crate::shims_emu::handle_shim_call(self);
-            // Treat any shim call as a single block and return here.
-            return;
+            return match self.emu.shims.get(eip) {
+                Some(Ok(shim)) => StopReason::ShimCall(shim),
+                Some(Err(name)) => StopReason::Error {
+                    message: format!("unimplemented shim {}", name),
+                    signal: 31, // SIGSYS
+                    eip,
+                },
+                None => StopReason::Error {
+                    message: format!("unknown shim call @ {:x}", eip),
+                    signal: 31, // SIGSYS
+                    eip,
+                },
+            };
         }
-        self.emu.x86.execute_block(self.emu.memory.mem())
+        self.emu
+            .x86
+            .execute_block(self.emu.memory.mem(), instruction_count);
+        let eip = self.emu.x86.cpu().regs.eip;
+        match &self.emu.x86.cpu().state {
+            x86::CPUState::Running | x86::CPUState::Blocked(_) => StopReason::None,
+            x86::CPUState::DebugBreak => StopReason::Breakpoint { eip },
+            x86::CPUState::Error(message) => StopReason::Error {
+                message: message.clone(),
+                signal: 11, // SIGSEGV, TODO?
+                eip,
+            },
+            x86::CPUState::Exit(code) => StopReason::Exit { code: *code },
+        }
     }
 
-    pub fn call_x86(
-        &mut self,
-        func: u32,
-        args: Vec<u32>,
-    ) -> impl std::future::Future<Output = u32> {
+    pub async fn call_x86(&mut self, func: u32, args: Vec<u32>) -> u32 {
         self.emu
             .x86
             .cpu_mut()
             .call_x86(self.emu.memory.mem(), func, args)
+            .await
     }
 
-    // pub fn dump_stack(&self) {
-    //     let esp = self.emu.x86.cpu.regs.esp;
-    //     for addr in ((esp - 0x10)..(esp + 0x10)).step_by(4) {
-    //         let extra = if addr == esp { " <- esp" } else { "" };
-    //         log::info!(
-    //             "{:08x} {:08x}{extra}",
-    //             addr,
-    //             self.mem().get_pod::<u32>(addr)
-    //         );
-    //     }
-    // }
-
-    pub fn snapshot(&self) -> Box<[u8]> {
-        bincode::serialize(&self.emu).unwrap().into()
-    }
-
-    pub fn load_snapshot(&mut self, bytes: &[u8]) {
-        self.emu = bincode::deserialize(bytes).unwrap();
+    /// Call a shim function. If it returns a future, it will be scheduled to run.
+    pub fn call_shim(&mut self, shim: &'static Shim) {
+        if let Some(future) = handle_shim_call(self, shim) {
+            self.emu.x86.cpu_mut().call_async(future);
+        }
     }
 
     /// Patch in an int3 over the instruction at that addr, backing up the current one.
-    pub fn add_breakpoint(&mut self, addr: u32) {
-        if crate::shims_emu::is_ip_at_shim_call(addr) {
-            self.emu.breakpoints.insert(addr, 0);
-        } else {
-            let mem = self.emu.memory.mem();
-            self.emu.breakpoints.insert(addr, mem.get_pod::<u8>(addr));
-            mem.put::<u8>(addr, 0xcc); // int3
-            self.emu.x86.icache.clear_cache(addr);
+    pub fn add_breakpoint(&mut self, addr: u32) -> bool {
+        match self.emu.breakpoints.entry(addr) {
+            std::collections::hash_map::Entry::Occupied(_) => false,
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                if crate::shims_emu::is_ip_at_shim_call(addr) {
+                    entry.insert(0);
+                } else {
+                    let mem = self.emu.memory.mem();
+                    entry.insert(mem.get_pod::<u8>(addr));
+                    mem.put::<u8>(addr, 0xcc); // int3
+                    self.emu.x86.icache.clear_cache(addr);
+                }
+                true
+            }
         }
     }
 
     /// Undo an add_breakpoint().
-    pub fn clear_breakpoint(&mut self, addr: u32) {
-        if crate::shims_emu::is_ip_at_shim_call(addr) {
-            self.emu.breakpoints.remove(&addr).unwrap();
-        } else {
-            self.emu.x86.icache.clear_cache(addr);
-            let prev = self.emu.breakpoints.remove(&addr).unwrap();
-            self.mem().put::<u8>(addr, prev);
+    pub fn clear_breakpoint(&mut self, addr: u32) -> bool {
+        match self.emu.breakpoints.remove(&addr) {
+            Some(prev) => {
+                if !crate::shims_emu::is_ip_at_shim_call(addr) {
+                    self.emu.x86.icache.clear_cache(addr);
+                    self.mem().put::<u8>(addr, prev);
+                }
+                true
+            }
+            None => false,
         }
+    }
+
+    pub fn exit(&mut self, code: u32) {
+        self.emu.x86.cpu_mut().state = x86::CPUState::Exit(code);
     }
 }

--- a/win32/src/machine_unicorn.rs
+++ b/win32/src/machine_unicorn.rs
@@ -1,20 +1,27 @@
+use crate::shims::Shim;
 use crate::{
     host,
     machine::{LoadedAddrs, MachineX},
     pe,
     shims_unicorn::Shims,
-    winapi,
+    winapi, StopReason,
 };
 use memory::Mem;
 use std::collections::HashMap;
+use std::future::Future;
+use std::path::Path;
+use std::pin::Pin;
+use std::task::Context;
+use unicorn_engine::unicorn_const::{uc_error, Arch, Mode, Permission};
+use unicorn_engine::{RegisterX86, Unicorn, X86Mmr};
 
-pub struct MemImpl(Box<[u8]>);
+pub struct MemImpl(Pin<Box<[u8]>>);
 
 impl MemImpl {
     pub fn new(size: usize) -> Self {
         let mut v = Vec::with_capacity(size);
         v.resize(size, 0);
-        Self(v.into_boxed_slice())
+        Self(Pin::from(v.into_boxed_slice()))
     }
 
     pub fn len(&self) -> u32 {
@@ -30,9 +37,12 @@ impl MemImpl {
 }
 
 pub struct Emulator {
-    pub unicorn: unicorn_engine::Unicorn<'static, ()>,
+    pub unicorn: Unicorn<'static, ()>,
     pub shims: Shims,
     pub memory: MemImpl,
+    breakpoints: HashMap<u32, *mut core::ffi::c_void>,
+    futures: Vec<Pin<Box<dyn Future<Output = ()>>>>,
+    exit_code: Option<u32>,
 }
 
 pub type Machine = MachineX<Emulator>;
@@ -42,18 +52,15 @@ impl MachineX<Emulator> {
         let mut memory = MemImpl::new(32 << 20);
         let mut kernel32 = winapi::kernel32::State::new(&mut memory, cmdline);
 
-        let mut unicorn = unicorn_engine::Unicorn::new(
-            unicorn_engine::unicorn_const::Arch::X86,
-            unicorn_engine::unicorn_const::Mode::MODE_32,
-        )
-        .unwrap();
+        let mut unicorn = Unicorn::new(Arch::X86, Mode::MODE_32).unwrap();
         unsafe {
+            let offset = 0x1000usize; // Leave the first 4k of memory unmapped
             unicorn
                 .mem_map_ptr(
-                    0,
-                    memory.len() as usize,
-                    unicorn_engine::unicorn_const::Permission::ALL,
-                    memory.ptr() as *mut _,
+                    offset as u64,
+                    (memory.len() as usize) - offset,
+                    Permission::ALL,
+                    memory.ptr().add(offset) as *mut _,
                 )
                 .unwrap();
         };
@@ -72,10 +79,14 @@ impl MachineX<Emulator> {
                 unicorn,
                 shims,
                 memory,
+                breakpoints: Default::default(),
+                futures: Default::default(),
+                exit_code: None,
             },
             host,
             state,
             labels: HashMap::new(),
+            exe_path: Default::default(),
         }
     }
 
@@ -95,11 +106,11 @@ impl MachineX<Emulator> {
         // TODO: put this init somewhere better.
         self.emu
             .unicorn
-            .reg_write(unicorn_engine::RegisterX86::ESP, stack_pointer as u64)
+            .reg_write(RegisterX86::ESP, stack_pointer as u64)
             .unwrap();
         self.emu
             .unicorn
-            .reg_write(unicorn_engine::RegisterX86::EBP, stack_pointer as u64)
+            .reg_write(RegisterX86::EBP, stack_pointer as u64)
             .unwrap();
 
         stack_pointer
@@ -113,7 +124,7 @@ impl MachineX<Emulator> {
         // https://github.com/unicorn-engine/unicorn/blob/master/samples/sample_x86_32_gdt_and_seg_regs.c
         let gdt = self.state.kernel32.create_gdt(self.emu.memory.mem());
 
-        let gdtr = unicorn_engine::X86Mmr {
+        let gdtr = X86Mmr {
             selector: 0, // unused
             base: gdt.addr as u64,
             limit: 5 * 8,
@@ -121,31 +132,28 @@ impl MachineX<Emulator> {
         };
         // Gross: need gdtr as a slice to pass to reg_write_long.
         let gdtr_slice = unsafe {
-            std::slice::from_raw_parts(
-                &gdtr as *const _ as *const u8,
-                std::mem::size_of::<unicorn_engine::X86Mmr>(),
-            )
+            std::slice::from_raw_parts(&gdtr as *const _ as *const u8, size_of::<X86Mmr>())
         };
 
         self.emu
             .unicorn
-            .reg_write_long(unicorn_engine::RegisterX86::GDTR, gdtr_slice)
+            .reg_write_long(RegisterX86::GDTR, gdtr_slice)
             .unwrap();
         self.emu
             .unicorn
-            .reg_write(unicorn_engine::RegisterX86::CS, gdt.cs as u64)
+            .reg_write(RegisterX86::CS, gdt.cs as u64)
             .unwrap();
         self.emu
             .unicorn
-            .reg_write(unicorn_engine::RegisterX86::DS, gdt.ds as u64)
+            .reg_write(RegisterX86::DS, gdt.ds as u64)
             .unwrap();
         self.emu
             .unicorn
-            .reg_write(unicorn_engine::RegisterX86::SS, gdt.ss as u64)
+            .reg_write(RegisterX86::SS, gdt.ss as u64)
             .unwrap();
         self.emu
             .unicorn
-            .reg_write(unicorn_engine::RegisterX86::FS, gdt.fs as u64)
+            .reg_write(RegisterX86::FS, gdt.fs as u64)
             .unwrap();
     }
 
@@ -153,52 +161,156 @@ impl MachineX<Emulator> {
     pub fn load_exe(
         &mut self,
         buf: &[u8],
-        filename: &str,
+        path: &Path,
         relocate: Option<Option<u32>>,
     ) -> anyhow::Result<LoadedAddrs> {
-        let exe = pe::load_exe(self, buf, filename, relocate)?;
+        let exe = pe::load_exe(self, buf, path, relocate)?;
 
         let stack_pointer = self.setup_stack(exe.stack_size);
         self.setup_segments();
 
         self.emu
             .unicorn
-            .reg_write(unicorn_engine::RegisterX86::EAX, 0xdeadbeea)
+            .reg_write(RegisterX86::EAX, 0xdeadbeea)
             .unwrap();
         self.emu
             .unicorn
-            .reg_write(unicorn_engine::RegisterX86::EBX, 0xdeadbeeb)
+            .reg_write(RegisterX86::EBX, 0xdeadbeeb)
+            .unwrap();
+        self.emu
+            .unicorn
+            .reg_write(RegisterX86::EIP, exe.entry_point as u64)
             .unwrap();
         // To make CPU traces match more closely, set up some registers to what their
         // initial values appear to be from looking in a debugger.
         self.emu
             .unicorn
-            .reg_write(unicorn_engine::RegisterX86::ECX, exe.entry_point as u64)
+            .reg_write(RegisterX86::ECX, exe.entry_point as u64)
             .unwrap();
         self.emu
             .unicorn
-            .reg_write(unicorn_engine::RegisterX86::EDX, exe.entry_point as u64)
+            .reg_write(RegisterX86::EDX, exe.entry_point as u64)
             .unwrap();
         self.emu
             .unicorn
-            .reg_write(unicorn_engine::RegisterX86::ESI, exe.entry_point as u64)
+            .reg_write(RegisterX86::ESI, exe.entry_point as u64)
             .unwrap();
         self.emu
             .unicorn
-            .reg_write(unicorn_engine::RegisterX86::EDI, exe.entry_point as u64)
+            .reg_write(RegisterX86::EDI, exe.entry_point as u64)
             .unwrap();
 
+        self.exe_path = path.to_path_buf();
         Ok(LoadedAddrs {
             entry_point: exe.entry_point,
             stack_pointer,
         })
     }
 
-    pub fn call_x86(
-        &mut self,
-        func: u32,
-        args: Vec<u32>,
-    ) -> impl std::future::Future<Output = u32> {
-        crate::shims_unicorn::call_x86(self, func, args)
+    pub async fn call_x86(&mut self, func: u32, args: Vec<u32>) -> u32 {
+        crate::shims_unicorn::call_x86(self, func, args).await
+    }
+
+    /// Call a shim function. If it returns a future, it will be scheduled to run.
+    pub fn call_shim(&mut self, shim: &'static Shim) {
+        if let Some(future) = crate::shims_unicorn::handle_shim_call(self, shim) {
+            self.emu
+                .unicorn
+                .reg_write(RegisterX86::EIP, crate::shims_unicorn::MAGIC_ADDR as u64)
+                .unwrap();
+            self.emu.futures.push(future);
+        }
+    }
+
+    pub fn run(&mut self, mut instruction_count: usize) -> StopReason {
+        if let Some(code) = self.emu.exit_code {
+            return StopReason::Exit { code };
+        }
+        let eip = self.emu.unicorn.reg_read(RegisterX86::EIP).unwrap();
+        if eip == crate::shims_unicorn::MAGIC_ADDR as u64 {
+            self.async_executor();
+            return StopReason::None;
+        }
+        if instruction_count == 0 {
+            // Insert some reasonable number of instructions per loop.
+            instruction_count = 10_000;
+        }
+        match self.emu.unicorn.emu_start(eip, 0, 0, instruction_count) {
+            Ok(()) => {}
+            Err(e) => {
+                let eip = self.emu.unicorn.reg_read(RegisterX86::EIP).unwrap() as u32;
+                return StopReason::Error {
+                    message: format!("{:?}", e),
+                    signal: match e {
+                        uc_error::NOMEM => 6,        // SIGABRT
+                        uc_error::INSN_INVALID => 4, // SIGILL
+                        _ => 11,                     // SIGSEGV
+                    },
+                    eip,
+                };
+            }
+        }
+        let eip = self.emu.unicorn.reg_read(RegisterX86::EIP).unwrap() as u32;
+        if self.emu.breakpoints.contains_key(&eip) {
+            StopReason::Breakpoint { eip }
+        } else if let Some(result) = self.emu.shims.get(eip) {
+            match result {
+                Ok(shim) => StopReason::ShimCall(shim),
+                Err(name) => StopReason::Error {
+                    message: format!("unimplemented shim {name}"),
+                    signal: 31, // SIGSYS
+                    eip,
+                },
+            }
+        } else {
+            StopReason::None
+        }
+    }
+
+    pub fn add_breakpoint(&mut self, addr: u32) -> bool {
+        match self.emu.breakpoints.entry(addr) {
+            std::collections::hash_map::Entry::Occupied(_) => {
+                log::warn!("machine_unicorn: breakpoint already set at {:#x}", addr);
+                false
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let hook = self
+                    .emu
+                    .unicorn
+                    .add_code_hook(addr as u64, (addr + 1) as u64, |u, addr, _size| {
+                        log::debug!("machine_unicorn: breakpoint hit at {:#x}", addr);
+                        u.emu_stop().unwrap()
+                    })
+                    .unwrap();
+                entry.insert(hook);
+                true
+            }
+        }
+    }
+
+    pub fn clear_breakpoint(&mut self, addr: u32) -> bool {
+        if let Some(hook) = self.emu.breakpoints.remove(&addr) {
+            self.emu.unicorn.remove_hook(hook).unwrap();
+            true
+        } else {
+            log::warn!("machine_unicorn: no breakpoint at {:#x}", addr);
+            false
+        }
+    }
+
+    pub fn exit(&mut self, code: u32) {
+        self.emu.exit_code = Some(code);
+    }
+
+    fn async_executor(&mut self) {
+        let future = self.emu.futures.last_mut().unwrap();
+        let mut ctx = Context::from_waker(futures::task::noop_waker_ref());
+        let poll = future.as_mut().poll(&mut ctx);
+        match poll {
+            std::task::Poll::Ready(()) => {
+                self.emu.futures.pop();
+            }
+            std::task::Poll::Pending => {}
+        }
     }
 }

--- a/win32/src/pe/loader.rs
+++ b/win32/src/pe/loader.rs
@@ -4,6 +4,7 @@ use super::{apply_relocs, IMAGE_DATA_DIRECTORY, IMAGE_SECTION_HEADER};
 use crate::{machine::Machine, pe, winapi};
 use memory::{ExtensionsMut, Mem};
 use std::collections::HashMap;
+use std::path::Path;
 
 /// Create a memory mapping, optionally copying some data to it.
 fn map_memory(machine: &mut Machine, mapping: winapi::kernel32::Mapping, buf: Option<&[u8]>) {
@@ -182,12 +183,13 @@ pub struct EXEFields {
 pub fn load_exe(
     machine: &mut Machine,
     buf: &[u8],
-    filename: &str,
+    path: &Path,
     relocate: Option<Option<u32>>,
 ) -> anyhow::Result<EXEFields> {
     let file = pe::parse(buf)?;
 
-    let base = load_pe(machine, filename, buf, &file, relocate)?;
+    let filename = path.file_name().unwrap().to_string_lossy();
+    let base = load_pe(machine, &filename, buf, &file, relocate)?;
     machine.state.kernel32.image_base = base;
 
     if let Some(res_data) = file

--- a/win32/src/shims.rs
+++ b/win32/src/shims.rs
@@ -12,10 +12,14 @@
 
 use crate::Machine;
 
-#[cfg(feature = "x86-unicorn")]
-pub use crate::shims_unicorn::unicorn_loop;
-
-pub type Handler = unsafe fn(&mut Machine, u32) -> u32;
+pub type SyncHandler = unsafe fn(&mut Machine, u32) -> u32;
+pub type AsyncHandler =
+    unsafe fn(&mut Machine, u32) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>>;
+#[derive(Debug, Clone, Copy)]
+pub enum Handler {
+    Sync(SyncHandler),
+    Async(AsyncHandler),
+}
 
 pub struct Shim {
     pub name: &'static str,
@@ -23,7 +27,6 @@ pub struct Shim {
     /// Number of stack bytes popped by arguments.
     /// For cdecl calling convention (used in varargs) this is 0.
     pub stack_consumed: u32,
-    pub is_async: bool,
 }
 
 pub struct UnimplFuture<T = ()> {

--- a/win32/src/shims_unicorn.rs
+++ b/win32/src/shims_unicorn.rs
@@ -8,8 +8,12 @@
 //! 3) tell Unicorn to stop emulation whenever the page is hit,
 //!    and use eip to compute which shim
 
-use crate::{shims::Shim, shims::UnimplFuture, Machine};
+use crate::shims::Handler;
+use crate::{shims::Shim, Machine};
 use memory::Extensions;
+use std::future::Future;
+use std::pin::Pin;
+use unicorn_engine::RegisterX86;
 
 #[derive(Default)]
 pub struct Shims {
@@ -18,11 +22,11 @@ pub struct Shims {
 }
 
 impl Shims {
-    pub fn new(unicorn: &mut unicorn_engine::Unicorn<'static, ()>, addr: u32) -> Self {
+    pub fn new(unicorn: &mut unicorn_engine::Unicorn<'static, ()>, hooks_base: u32) -> Self {
         unicorn
             .add_code_hook(
-                addr as u64,
-                addr as u64 + 0x1000,
+                hooks_base as u64,
+                hooks_base as u64 + 0x1000,
                 |unicorn, _addr, _size| {
                     unicorn.emu_stop().unwrap();
                 },
@@ -37,7 +41,7 @@ impl Shims {
 
         Shims {
             shims: Default::default(),
-            hooks_base: addr,
+            hooks_base,
         }
     }
 
@@ -47,113 +51,126 @@ impl Shims {
         self.shims.push(shim);
         addr
     }
+
+    pub fn get(&self, addr: u32) -> Option<Result<&'static Shim, &str>> {
+        if (self.hooks_base..self.hooks_base + 0x1000).contains(&addr) {
+            let index = (addr - self.hooks_base) as usize;
+            self.shims.get(index).map(|result| match result {
+                Ok(shim) => Ok(*shim),
+                Err(name) => Err(name.as_str()),
+            })
+        } else {
+            None
+        }
+    }
 }
 
-/// Handle a call to a shim.  Expects eip to point somewhere within the hooks_base page.
-fn handle_shim_call(machine: &mut Machine) -> u32 {
-    let eip = machine
-        .emu
-        .unicorn
-        .reg_read(unicorn_engine::RegisterX86::EIP)
-        .unwrap() as u32;
-    let index = eip - machine.emu.shims.hooks_base;
-    let shim = match &machine.emu.shims.shims[index as usize] {
-        Ok(shim) => shim,
-        Err(name) => unimplemented!("shim call to {name}"),
-    };
+/// When eip==MAGIC_ADDR, the CPU executes futures (async tasks) rather than x86 code.
+pub const MAGIC_ADDR: u32 = 0xFFFF_FFF0;
 
-    let crate::shims::Shim {
+/// Handle a call to a shim.
+pub fn handle_shim_call(
+    machine: &mut Machine,
+    shim: &'static Shim,
+) -> Option<Pin<Box<dyn Future<Output = ()>>>> {
+    let Shim {
         func,
         stack_consumed,
         ..
     } = *shim;
-
-    let esp = machine
-        .emu
-        .unicorn
-        .reg_read(unicorn_engine::RegisterX86::ESP)
-        .unwrap() as u32;
-    let ret = unsafe { func(machine, esp) };
-
-    let ret_addr = machine.mem().get_pod::<u32>(esp);
-    machine
-        .emu
-        .unicorn
-        .reg_write(unicorn_engine::RegisterX86::EIP, ret_addr as u64)
-        .unwrap();
-    machine
-        .emu
-        .unicorn
-        .reg_write(
-            unicorn_engine::RegisterX86::ESP,
-            (esp + stack_consumed + 4) as u64,
-        )
-        .unwrap();
-    machine
-        .emu
-        .unicorn
-        .reg_write(unicorn_engine::RegisterX86::EAX, ret as u64)
-        .unwrap();
-
-    ret_addr
+    match func {
+        Handler::Sync(func) => {
+            let esp = machine.emu.unicorn.reg_read(RegisterX86::ESP).unwrap() as u32;
+            let ret = unsafe { func(machine, esp) };
+            let ret_addr = machine.mem().get_pod::<u32>(esp);
+            machine
+                .emu
+                .unicorn
+                .reg_write(RegisterX86::EIP, ret_addr as u64)
+                .unwrap();
+            machine
+                .emu
+                .unicorn
+                .reg_write(RegisterX86::ESP, (esp + stack_consumed + 4) as u64)
+                .unwrap();
+            machine
+                .emu
+                .unicorn
+                .reg_write(RegisterX86::EAX, ret as u64)
+                .unwrap();
+            None
+        }
+        Handler::Async(func) => {
+            let machine: *mut Machine = machine;
+            Some(Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                let esp = machine.emu.unicorn.reg_read(RegisterX86::ESP).unwrap() as u32;
+                let ret = unsafe { func(machine, esp) }.await;
+                let ret_addr = machine.mem().get_pod::<u32>(esp);
+                machine
+                    .emu
+                    .unicorn
+                    .reg_write(RegisterX86::EIP, ret_addr as u64)
+                    .unwrap();
+                machine
+                    .emu
+                    .unicorn
+                    .reg_write(RegisterX86::ESP, (esp + stack_consumed + 4) as u64)
+                    .unwrap();
+                machine
+                    .emu
+                    .unicorn
+                    .reg_write(RegisterX86::EAX, ret as u64)
+                    .unwrap();
+            }))
+        }
+    }
 }
 
-pub fn call_x86(machine: &mut Machine, func: u32, args: Vec<u32>) -> UnimplFuture<u32> {
+struct UnicornFuture {
+    // We assume the machine is around for the duration of the future execution.
+    // https://github.com/rust-lang/futures-rs/issues/316
+    machine: *mut Machine,
+    esp: u32,
+}
+impl Future for UnicornFuture {
+    type Output = u32;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let machine = unsafe { &mut *self.machine };
+        if machine.emu.unicorn.reg_read(RegisterX86::ESP).unwrap() as u32 == self.esp {
+            std::task::Poll::Ready(machine.emu.unicorn.reg_read(RegisterX86::EAX).unwrap() as u32)
+        } else {
+            std::task::Poll::Pending
+        }
+    }
+}
+
+pub fn call_x86(machine: &mut Machine, func: u32, args: Vec<u32>) -> impl Future<Output = u32> {
     let mem = machine.emu.memory.mem();
 
-    let ret_addr = machine
-        .emu
-        .unicorn
-        .reg_read(unicorn_engine::RegisterX86::EIP)
-        .unwrap() as u32;
-
-    let mut esp = machine
-        .emu
-        .unicorn
-        .reg_read(unicorn_engine::RegisterX86::ESP)
-        .unwrap() as u32;
+    let esp = machine.emu.unicorn.reg_read(RegisterX86::ESP).unwrap() as u32;
+    let mut new_esp = esp;
     for &arg in args.iter().rev() {
-        esp -= 4;
-        mem.put(esp, arg);
+        new_esp -= 4;
+        mem.put(new_esp, arg);
     }
-    esp -= 4;
-    mem.put(esp, ret_addr);
+    new_esp -= 4;
+    mem.put(new_esp, MAGIC_ADDR);
 
     machine
         .emu
         .unicorn
-        .reg_write(unicorn_engine::RegisterX86::ESP, esp as u64)
+        .reg_write(RegisterX86::ESP, new_esp as u64)
         .unwrap();
-
-    unicorn_loop(machine, func, ret_addr);
-
-    let ret = machine
+    machine
         .emu
         .unicorn
-        .reg_read(unicorn_engine::RegisterX86::EAX)
-        .unwrap() as u32;
-    UnimplFuture::new(ret)
-}
+        .reg_write(RegisterX86::EIP, func as u64)
+        .unwrap();
 
-/// Run emulation via machine.emu starting from eip=begin until eip==until is hit.
-/// This is like unicorn.emu_start() but handles shim calls as well.
-pub fn unicorn_loop(machine: &mut Machine, begin: u32, until: u32) {
-    let mut eip = begin as u64;
-    let until = until as u64;
-    loop {
-        machine.emu.unicorn.emu_start(eip, until, 0, 0).unwrap();
-        eip = machine
-            .emu
-            .unicorn
-            .reg_read(unicorn_engine::RegisterX86::EIP)
-            .unwrap();
-        if eip == until {
-            return;
-        }
-        if (machine.emu.shims.hooks_base..machine.emu.shims.hooks_base + 0x1000)
-            .contains(&(eip as u32))
-        {
-            eip = handle_shim_call(machine) as u64;
-        }
-    }
+    UnicornFuture { machine, esp }
 }

--- a/win32/src/winapi/builtin.rs
+++ b/win32/src/winapi/builtin.rs
@@ -94,30 +94,26 @@ pub mod advapi32 {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const RegCloseKey: Shim = Shim {
+        use crate::shims;
+        pub const RegCloseKey: shims::Shim = shims::Shim {
             name: "RegCloseKey",
-            func: impls::RegCloseKey,
+            func: shims::Handler::Sync(impls::RegCloseKey),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const RegCreateKeyExW: Shim = Shim {
+        pub const RegCreateKeyExW: shims::Shim = shims::Shim {
             name: "RegCreateKeyExW",
-            func: impls::RegCreateKeyExW,
+            func: shims::Handler::Sync(impls::RegCreateKeyExW),
             stack_consumed: 36u32,
-            is_async: false,
         };
-        pub const RegQueryValueExW: Shim = Shim {
+        pub const RegQueryValueExW: shims::Shim = shims::Shim {
             name: "RegQueryValueExW",
-            func: impls::RegQueryValueExW,
+            func: shims::Handler::Sync(impls::RegQueryValueExW),
             stack_consumed: 24u32,
-            is_async: false,
         };
-        pub const RegSetValueExW: Shim = Shim {
+        pub const RegSetValueExW: shims::Shim = shims::Shim {
             name: "RegSetValueExW",
-            func: impls::RegSetValueExW,
+            func: shims::Handler::Sync(impls::RegSetValueExW),
             stack_consumed: 24u32,
-            is_async: false,
         };
     }
     const EXPORTS: [Symbol; 4usize] = [
@@ -193,42 +189,36 @@ pub mod bass {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const BASS_ChannelGetPosition: Shim = Shim {
+        use crate::shims;
+        pub const BASS_ChannelGetPosition: shims::Shim = shims::Shim {
             name: "BASS_ChannelGetPosition",
-            func: impls::BASS_ChannelGetPosition,
+            func: shims::Handler::Sync(impls::BASS_ChannelGetPosition),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const BASS_Init: Shim = Shim {
+        pub const BASS_Init: shims::Shim = shims::Shim {
             name: "BASS_Init",
-            func: impls::BASS_Init,
+            func: shims::Handler::Sync(impls::BASS_Init),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const BASS_MusicLoad: Shim = Shim {
+        pub const BASS_MusicLoad: shims::Shim = shims::Shim {
             name: "BASS_MusicLoad",
-            func: impls::BASS_MusicLoad,
+            func: shims::Handler::Sync(impls::BASS_MusicLoad),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const BASS_MusicPlay: Shim = Shim {
+        pub const BASS_MusicPlay: shims::Shim = shims::Shim {
             name: "BASS_MusicPlay",
-            func: impls::BASS_MusicPlay,
+            func: shims::Handler::Sync(impls::BASS_MusicPlay),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const BASS_MusicSetPositionScaler: Shim = Shim {
+        pub const BASS_MusicSetPositionScaler: shims::Shim = shims::Shim {
             name: "BASS_MusicSetPositionScaler",
-            func: impls::BASS_MusicSetPositionScaler,
+            func: shims::Handler::Sync(impls::BASS_MusicSetPositionScaler),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const BASS_Start: Shim = Shim {
+        pub const BASS_Start: shims::Shim = shims::Shim {
             name: "BASS_Start",
-            func: impls::BASS_Start,
+            func: shims::Handler::Sync(impls::BASS_Start),
             stack_consumed: 0u32,
-            is_async: false,
         };
     }
     const EXPORTS: [Symbol; 6usize] = [
@@ -298,24 +288,21 @@ pub mod ddraw {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const DirectDrawCreate: Shim = Shim {
+        use crate::shims;
+        pub const DirectDrawCreate: shims::Shim = shims::Shim {
             name: "DirectDrawCreate",
-            func: impls::DirectDrawCreate,
+            func: shims::Handler::Sync(impls::DirectDrawCreate),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const DirectDrawCreateClipper: Shim = Shim {
+        pub const DirectDrawCreateClipper: shims::Shim = shims::Shim {
             name: "DirectDrawCreateClipper",
-            func: impls::DirectDrawCreateClipper,
+            func: shims::Handler::Sync(impls::DirectDrawCreateClipper),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const DirectDrawCreateEx: Shim = Shim {
+        pub const DirectDrawCreateEx: shims::Shim = shims::Shim {
             name: "DirectDrawCreateEx",
-            func: impls::DirectDrawCreateEx,
+            func: shims::Handler::Sync(impls::DirectDrawCreateEx),
             stack_consumed: 16u32,
-            is_async: false,
         };
     }
     const EXPORTS: [Symbol; 3usize] = [
@@ -363,18 +350,16 @@ pub mod dsound {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const DirectSoundCreate: Shim = Shim {
+        use crate::shims;
+        pub const DirectSoundCreate: shims::Shim = shims::Shim {
             name: "DirectSoundCreate",
-            func: impls::DirectSoundCreate,
+            func: shims::Handler::Sync(impls::DirectSoundCreate),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const DirectSoundEnumerateA: Shim = Shim {
+        pub const DirectSoundEnumerateA: shims::Shim = shims::Shim {
             name: "DirectSoundEnumerateA",
-            func: impls::DirectSoundEnumerateA,
+            func: shims::Handler::Sync(impls::DirectSoundEnumerateA),
             stack_consumed: 8u32,
-            is_async: false,
         };
     }
     const EXPORTS: [Symbol; 2usize] = [
@@ -735,228 +720,191 @@ pub mod gdi32 {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const BitBlt: Shim = Shim {
+        use crate::shims;
+        pub const BitBlt: shims::Shim = shims::Shim {
             name: "BitBlt",
-            func: impls::BitBlt,
+            func: shims::Handler::Sync(impls::BitBlt),
             stack_consumed: 36u32,
-            is_async: false,
         };
-        pub const CreateBitmap: Shim = Shim {
+        pub const CreateBitmap: shims::Shim = shims::Shim {
             name: "CreateBitmap",
-            func: impls::CreateBitmap,
+            func: shims::Handler::Sync(impls::CreateBitmap),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const CreateCompatibleBitmap: Shim = Shim {
+        pub const CreateCompatibleBitmap: shims::Shim = shims::Shim {
             name: "CreateCompatibleBitmap",
-            func: impls::CreateCompatibleBitmap,
+            func: shims::Handler::Sync(impls::CreateCompatibleBitmap),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const CreateCompatibleDC: Shim = Shim {
+        pub const CreateCompatibleDC: shims::Shim = shims::Shim {
             name: "CreateCompatibleDC",
-            func: impls::CreateCompatibleDC,
+            func: shims::Handler::Sync(impls::CreateCompatibleDC),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const CreateDIBSection: Shim = Shim {
+        pub const CreateDIBSection: shims::Shim = shims::Shim {
             name: "CreateDIBSection",
-            func: impls::CreateDIBSection,
+            func: shims::Handler::Sync(impls::CreateDIBSection),
             stack_consumed: 24u32,
-            is_async: false,
         };
-        pub const CreateFontA: Shim = Shim {
+        pub const CreateFontA: shims::Shim = shims::Shim {
             name: "CreateFontA",
-            func: impls::CreateFontA,
+            func: shims::Handler::Sync(impls::CreateFontA),
             stack_consumed: 56u32,
-            is_async: false,
         };
-        pub const CreatePen: Shim = Shim {
+        pub const CreatePen: shims::Shim = shims::Shim {
             name: "CreatePen",
-            func: impls::CreatePen,
+            func: shims::Handler::Sync(impls::CreatePen),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const CreateSolidBrush: Shim = Shim {
+        pub const CreateSolidBrush: shims::Shim = shims::Shim {
             name: "CreateSolidBrush",
-            func: impls::CreateSolidBrush,
+            func: shims::Handler::Sync(impls::CreateSolidBrush),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const DeleteDC: Shim = Shim {
+        pub const DeleteDC: shims::Shim = shims::Shim {
             name: "DeleteDC",
-            func: impls::DeleteDC,
+            func: shims::Handler::Sync(impls::DeleteDC),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const DeleteObject: Shim = Shim {
+        pub const DeleteObject: shims::Shim = shims::Shim {
             name: "DeleteObject",
-            func: impls::DeleteObject,
+            func: shims::Handler::Sync(impls::DeleteObject),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetDCOrgEx: Shim = Shim {
+        pub const GetDCOrgEx: shims::Shim = shims::Shim {
             name: "GetDCOrgEx",
-            func: impls::GetDCOrgEx,
+            func: shims::Handler::Sync(impls::GetDCOrgEx),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetDeviceCaps: Shim = Shim {
+        pub const GetDeviceCaps: shims::Shim = shims::Shim {
             name: "GetDeviceCaps",
-            func: impls::GetDeviceCaps,
+            func: shims::Handler::Sync(impls::GetDeviceCaps),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetLayout: Shim = Shim {
+        pub const GetLayout: shims::Shim = shims::Shim {
             name: "GetLayout",
-            func: impls::GetLayout,
+            func: shims::Handler::Sync(impls::GetLayout),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetObjectA: Shim = Shim {
+        pub const GetObjectA: shims::Shim = shims::Shim {
             name: "GetObjectA",
-            func: impls::GetObjectA,
+            func: shims::Handler::Sync(impls::GetObjectA),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const GetPixel: Shim = Shim {
+        pub const GetPixel: shims::Shim = shims::Shim {
             name: "GetPixel",
-            func: impls::GetPixel,
+            func: shims::Handler::Sync(impls::GetPixel),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const GetStockObject: Shim = Shim {
+        pub const GetStockObject: shims::Shim = shims::Shim {
             name: "GetStockObject",
-            func: impls::GetStockObject,
+            func: shims::Handler::Sync(impls::GetStockObject),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetTextExtentPoint32A: Shim = Shim {
+        pub const GetTextExtentPoint32A: shims::Shim = shims::Shim {
             name: "GetTextExtentPoint32A",
-            func: impls::GetTextExtentPoint32A,
+            func: shims::Handler::Sync(impls::GetTextExtentPoint32A),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const GetTextExtentPoint32W: Shim = Shim {
+        pub const GetTextExtentPoint32W: shims::Shim = shims::Shim {
             name: "GetTextExtentPoint32W",
-            func: impls::GetTextExtentPoint32W,
+            func: shims::Handler::Sync(impls::GetTextExtentPoint32W),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const GetTextMetricsA: Shim = Shim {
+        pub const GetTextMetricsA: shims::Shim = shims::Shim {
             name: "GetTextMetricsA",
-            func: impls::GetTextMetricsA,
+            func: shims::Handler::Sync(impls::GetTextMetricsA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetTextMetricsW: Shim = Shim {
+        pub const GetTextMetricsW: shims::Shim = shims::Shim {
             name: "GetTextMetricsW",
-            func: impls::GetTextMetricsW,
+            func: shims::Handler::Sync(impls::GetTextMetricsW),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const LineDDA: Shim = Shim {
+        pub const LineDDA: shims::Shim = shims::Shim {
             name: "LineDDA",
-            func: impls::LineDDA,
+            func: shims::Handler::Sync(impls::LineDDA),
             stack_consumed: 24u32,
-            is_async: false,
         };
-        pub const LineTo: Shim = Shim {
+        pub const LineTo: shims::Shim = shims::Shim {
             name: "LineTo",
-            func: impls::LineTo,
+            func: shims::Handler::Sync(impls::LineTo),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const MoveToEx: Shim = Shim {
+        pub const MoveToEx: shims::Shim = shims::Shim {
             name: "MoveToEx",
-            func: impls::MoveToEx,
+            func: shims::Handler::Sync(impls::MoveToEx),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const PatBlt: Shim = Shim {
+        pub const PatBlt: shims::Shim = shims::Shim {
             name: "PatBlt",
-            func: impls::PatBlt,
+            func: shims::Handler::Sync(impls::PatBlt),
             stack_consumed: 24u32,
-            is_async: false,
         };
-        pub const PtVisible: Shim = Shim {
+        pub const PtVisible: shims::Shim = shims::Shim {
             name: "PtVisible",
-            func: impls::PtVisible,
+            func: shims::Handler::Sync(impls::PtVisible),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const SelectObject: Shim = Shim {
+        pub const SelectObject: shims::Shim = shims::Shim {
             name: "SelectObject",
-            func: impls::SelectObject,
+            func: shims::Handler::Sync(impls::SelectObject),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const SetBkColor: Shim = Shim {
+        pub const SetBkColor: shims::Shim = shims::Shim {
             name: "SetBkColor",
-            func: impls::SetBkColor,
+            func: shims::Handler::Sync(impls::SetBkColor),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const SetBkMode: Shim = Shim {
+        pub const SetBkMode: shims::Shim = shims::Shim {
             name: "SetBkMode",
-            func: impls::SetBkMode,
+            func: shims::Handler::Sync(impls::SetBkMode),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const SetBrushOrgEx: Shim = Shim {
+        pub const SetBrushOrgEx: shims::Shim = shims::Shim {
             name: "SetBrushOrgEx",
-            func: impls::SetBrushOrgEx,
+            func: shims::Handler::Sync(impls::SetBrushOrgEx),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const SetDIBitsToDevice: Shim = Shim {
+        pub const SetDIBitsToDevice: shims::Shim = shims::Shim {
             name: "SetDIBitsToDevice",
-            func: impls::SetDIBitsToDevice,
+            func: shims::Handler::Sync(impls::SetDIBitsToDevice),
             stack_consumed: 48u32,
-            is_async: false,
         };
-        pub const SetPixel: Shim = Shim {
+        pub const SetPixel: shims::Shim = shims::Shim {
             name: "SetPixel",
-            func: impls::SetPixel,
+            func: shims::Handler::Sync(impls::SetPixel),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const SetROP2: Shim = Shim {
+        pub const SetROP2: shims::Shim = shims::Shim {
             name: "SetROP2",
-            func: impls::SetROP2,
+            func: shims::Handler::Sync(impls::SetROP2),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const SetTextColor: Shim = Shim {
+        pub const SetTextColor: shims::Shim = shims::Shim {
             name: "SetTextColor",
-            func: impls::SetTextColor,
+            func: shims::Handler::Sync(impls::SetTextColor),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const StretchBlt: Shim = Shim {
+        pub const StretchBlt: shims::Shim = shims::Shim {
             name: "StretchBlt",
-            func: impls::StretchBlt,
+            func: shims::Handler::Sync(impls::StretchBlt),
             stack_consumed: 44u32,
-            is_async: false,
         };
-        pub const StretchDIBits: Shim = Shim {
+        pub const StretchDIBits: shims::Shim = shims::Shim {
             name: "StretchDIBits",
-            func: impls::StretchDIBits,
+            func: shims::Handler::Sync(impls::StretchDIBits),
             stack_consumed: 52u32,
-            is_async: false,
         };
-        pub const TextOutA: Shim = Shim {
+        pub const TextOutA: shims::Shim = shims::Shim {
             name: "TextOutA",
-            func: impls::TextOutA,
+            func: shims::Handler::Sync(impls::TextOutA),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const TextOutW: Shim = Shim {
+        pub const TextOutW: shims::Shim = shims::Shim {
             name: "TextOutW",
-            func: impls::TextOutW,
+            func: shims::Handler::Sync(impls::TextOutW),
             stack_consumed: 20u32,
-            is_async: false,
         };
     }
     const EXPORTS: [Symbol; 37usize] = [
@@ -1210,7 +1158,10 @@ pub mod kernel32 {
             )
             .to_raw()
         }
-        pub unsafe fn CreateThread(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn CreateThread(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let lpThreadAttributes = <u32>::from_stack(mem, esp + 4u32);
             let dwStackSize = <u32>::from_stack(mem, esp + 8u32);
@@ -1218,43 +1169,21 @@ pub mod kernel32 {
             let lpParameter = <u32>::from_stack(mem, esp + 16u32);
             let dwCreationFlags = <u32>::from_stack(mem, esp + 20u32);
             let lpThreadId = <u32>::from_stack(mem, esp + 24u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::kernel32::CreateThread(
-                        machine,
-                        lpThreadAttributes,
-                        dwStackSize,
-                        lpStartAddress,
-                        lpParameter,
-                        dwCreationFlags,
-                        lpThreadId,
-                    )
-                    .await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 24u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::kernel32::CreateThread(
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::kernel32::CreateThread(
                     machine,
                     lpThreadAttributes,
                     dwStackSize,
                     lpStartAddress,
                     lpParameter,
                     dwCreationFlags,
-                    lpThreadId
-                ));
-                crate::shims::call_sync(pin).to_raw()
-            }
+                    lpThreadId,
+                )
+                .await
+                .to_raw()
+            })
         }
         pub unsafe fn DeleteCriticalSection(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -2046,29 +1975,19 @@ pub mod kernel32 {
             winapi::kernel32::SetUnhandledExceptionFilter(machine, _lpTopLevelExceptionFilter)
                 .to_raw()
         }
-        pub unsafe fn Sleep(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn Sleep(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let dwMilliseconds = <u32>::from_stack(mem, esp + 4u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::kernel32::Sleep(machine, dwMilliseconds).await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 4u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::kernel32::Sleep(machine, dwMilliseconds));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::kernel32::Sleep(machine, dwMilliseconds)
+                    .await
+                    .to_raw()
+            })
         }
         pub unsafe fn SystemTimeToFileTime(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -2223,951 +2142,778 @@ pub mod kernel32 {
             let lpString = <Option<&Str16>>::from_stack(mem, esp + 4u32);
             winapi::kernel32::lstrlenW(machine, lpString).to_raw()
         }
-        pub unsafe fn retrowin32_main(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn retrowin32_main(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let entry_point = <u32>::from_stack(mem, esp + 4u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::kernel32::retrowin32_main(machine, entry_point).await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 4u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::kernel32::retrowin32_main(machine, entry_point));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::kernel32::retrowin32_main(machine, entry_point)
+                    .await
+                    .to_raw()
+            })
         }
-        pub unsafe fn retrowin32_thread_main(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn retrowin32_thread_main(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let entry_point = <u32>::from_stack(mem, esp + 4u32);
             let param = <u32>::from_stack(mem, esp + 8u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result =
-                        winapi::kernel32::retrowin32_thread_main(machine, entry_point, param).await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 8u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::kernel32::retrowin32_thread_main(
-                    machine,
-                    entry_point,
-                    param
-                ));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::kernel32::retrowin32_thread_main(machine, entry_point, param)
+                    .await
+                    .to_raw()
+            })
         }
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const AcquireSRWLockExclusive: Shim = Shim {
+        use crate::shims;
+        pub const AcquireSRWLockExclusive: shims::Shim = shims::Shim {
             name: "AcquireSRWLockExclusive",
-            func: impls::AcquireSRWLockExclusive,
+            func: shims::Handler::Sync(impls::AcquireSRWLockExclusive),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const AcquireSRWLockShared: Shim = Shim {
+        pub const AcquireSRWLockShared: shims::Shim = shims::Shim {
             name: "AcquireSRWLockShared",
-            func: impls::AcquireSRWLockShared,
+            func: shims::Handler::Sync(impls::AcquireSRWLockShared),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const AddVectoredExceptionHandler: Shim = Shim {
+        pub const AddVectoredExceptionHandler: shims::Shim = shims::Shim {
             name: "AddVectoredExceptionHandler",
-            func: impls::AddVectoredExceptionHandler,
+            func: shims::Handler::Sync(impls::AddVectoredExceptionHandler),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const CloseHandle: Shim = Shim {
+        pub const CloseHandle: shims::Shim = shims::Shim {
             name: "CloseHandle",
-            func: impls::CloseHandle,
+            func: shims::Handler::Sync(impls::CloseHandle),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const CreateDirectoryA: Shim = Shim {
+        pub const CreateDirectoryA: shims::Shim = shims::Shim {
             name: "CreateDirectoryA",
-            func: impls::CreateDirectoryA,
+            func: shims::Handler::Sync(impls::CreateDirectoryA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const CreateEventA: Shim = Shim {
+        pub const CreateEventA: shims::Shim = shims::Shim {
             name: "CreateEventA",
-            func: impls::CreateEventA,
+            func: shims::Handler::Sync(impls::CreateEventA),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const CreateFileA: Shim = Shim {
+        pub const CreateFileA: shims::Shim = shims::Shim {
             name: "CreateFileA",
-            func: impls::CreateFileA,
+            func: shims::Handler::Sync(impls::CreateFileA),
             stack_consumed: 28u32,
-            is_async: false,
         };
-        pub const CreateFileW: Shim = Shim {
+        pub const CreateFileW: shims::Shim = shims::Shim {
             name: "CreateFileW",
-            func: impls::CreateFileW,
+            func: shims::Handler::Sync(impls::CreateFileW),
             stack_consumed: 28u32,
-            is_async: false,
         };
-        pub const CreateThread: Shim = Shim {
+        pub const CreateThread: shims::Shim = shims::Shim {
             name: "CreateThread",
-            func: impls::CreateThread,
+            func: shims::Handler::Async(impls::CreateThread),
             stack_consumed: 24u32,
-            is_async: true,
         };
-        pub const DeleteCriticalSection: Shim = Shim {
+        pub const DeleteCriticalSection: shims::Shim = shims::Shim {
             name: "DeleteCriticalSection",
-            func: impls::DeleteCriticalSection,
+            func: shims::Handler::Sync(impls::DeleteCriticalSection),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const DeleteFileA: Shim = Shim {
+        pub const DeleteFileA: shims::Shim = shims::Shim {
             name: "DeleteFileA",
-            func: impls::DeleteFileA,
+            func: shims::Handler::Sync(impls::DeleteFileA),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const DisableThreadLibraryCalls: Shim = Shim {
+        pub const DisableThreadLibraryCalls: shims::Shim = shims::Shim {
             name: "DisableThreadLibraryCalls",
-            func: impls::DisableThreadLibraryCalls,
+            func: shims::Handler::Sync(impls::DisableThreadLibraryCalls),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const EnterCriticalSection: Shim = Shim {
+        pub const EnterCriticalSection: shims::Shim = shims::Shim {
             name: "EnterCriticalSection",
-            func: impls::EnterCriticalSection,
+            func: shims::Handler::Sync(impls::EnterCriticalSection),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const ExitProcess: Shim = Shim {
+        pub const ExitProcess: shims::Shim = shims::Shim {
             name: "ExitProcess",
-            func: impls::ExitProcess,
+            func: shims::Handler::Sync(impls::ExitProcess),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const FileTimeToSystemTime: Shim = Shim {
+        pub const FileTimeToSystemTime: shims::Shim = shims::Shim {
             name: "FileTimeToSystemTime",
-            func: impls::FileTimeToSystemTime,
+            func: shims::Handler::Sync(impls::FileTimeToSystemTime),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const FindClose: Shim = Shim {
+        pub const FindClose: shims::Shim = shims::Shim {
             name: "FindClose",
-            func: impls::FindClose,
+            func: shims::Handler::Sync(impls::FindClose),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const FindFirstFileA: Shim = Shim {
+        pub const FindFirstFileA: shims::Shim = shims::Shim {
             name: "FindFirstFileA",
-            func: impls::FindFirstFileA,
+            func: shims::Handler::Sync(impls::FindFirstFileA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const FindNextFileA: Shim = Shim {
+        pub const FindNextFileA: shims::Shim = shims::Shim {
             name: "FindNextFileA",
-            func: impls::FindNextFileA,
+            func: shims::Handler::Sync(impls::FindNextFileA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const FindResourceA: Shim = Shim {
+        pub const FindResourceA: shims::Shim = shims::Shim {
             name: "FindResourceA",
-            func: impls::FindResourceA,
+            func: shims::Handler::Sync(impls::FindResourceA),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const FindResourceW: Shim = Shim {
+        pub const FindResourceW: shims::Shim = shims::Shim {
             name: "FindResourceW",
-            func: impls::FindResourceW,
+            func: shims::Handler::Sync(impls::FindResourceW),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const FormatMessageA: Shim = Shim {
+        pub const FormatMessageA: shims::Shim = shims::Shim {
             name: "FormatMessageA",
-            func: impls::FormatMessageA,
+            func: shims::Handler::Sync(impls::FormatMessageA),
             stack_consumed: 28u32,
-            is_async: false,
         };
-        pub const FormatMessageW: Shim = Shim {
+        pub const FormatMessageW: shims::Shim = shims::Shim {
             name: "FormatMessageW",
-            func: impls::FormatMessageW,
+            func: shims::Handler::Sync(impls::FormatMessageW),
             stack_consumed: 28u32,
-            is_async: false,
         };
-        pub const FreeEnvironmentStringsA: Shim = Shim {
+        pub const FreeEnvironmentStringsA: shims::Shim = shims::Shim {
             name: "FreeEnvironmentStringsA",
-            func: impls::FreeEnvironmentStringsA,
+            func: shims::Handler::Sync(impls::FreeEnvironmentStringsA),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const FreeLibrary: Shim = Shim {
+        pub const FreeLibrary: shims::Shim = shims::Shim {
             name: "FreeLibrary",
-            func: impls::FreeLibrary,
+            func: shims::Handler::Sync(impls::FreeLibrary),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetACP: Shim = Shim {
+        pub const GetACP: shims::Shim = shims::Shim {
             name: "GetACP",
-            func: impls::GetACP,
+            func: shims::Handler::Sync(impls::GetACP),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetCPInfo: Shim = Shim {
+        pub const GetCPInfo: shims::Shim = shims::Shim {
             name: "GetCPInfo",
-            func: impls::GetCPInfo,
+            func: shims::Handler::Sync(impls::GetCPInfo),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetCommandLineA: Shim = Shim {
+        pub const GetCommandLineA: shims::Shim = shims::Shim {
             name: "GetCommandLineA",
-            func: impls::GetCommandLineA,
+            func: shims::Handler::Sync(impls::GetCommandLineA),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetCommandLineW: Shim = Shim {
+        pub const GetCommandLineW: shims::Shim = shims::Shim {
             name: "GetCommandLineW",
-            func: impls::GetCommandLineW,
+            func: shims::Handler::Sync(impls::GetCommandLineW),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetConsoleMode: Shim = Shim {
+        pub const GetConsoleMode: shims::Shim = shims::Shim {
             name: "GetConsoleMode",
-            func: impls::GetConsoleMode,
+            func: shims::Handler::Sync(impls::GetConsoleMode),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetConsoleScreenBufferInfo: Shim = Shim {
+        pub const GetConsoleScreenBufferInfo: shims::Shim = shims::Shim {
             name: "GetConsoleScreenBufferInfo",
-            func: impls::GetConsoleScreenBufferInfo,
+            func: shims::Handler::Sync(impls::GetConsoleScreenBufferInfo),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetCurrentDirectoryA: Shim = Shim {
+        pub const GetCurrentDirectoryA: shims::Shim = shims::Shim {
             name: "GetCurrentDirectoryA",
-            func: impls::GetCurrentDirectoryA,
+            func: shims::Handler::Sync(impls::GetCurrentDirectoryA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetCurrentProcessId: Shim = Shim {
+        pub const GetCurrentProcessId: shims::Shim = shims::Shim {
             name: "GetCurrentProcessId",
-            func: impls::GetCurrentProcessId,
+            func: shims::Handler::Sync(impls::GetCurrentProcessId),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetCurrentThread: Shim = Shim {
+        pub const GetCurrentThread: shims::Shim = shims::Shim {
             name: "GetCurrentThread",
-            func: impls::GetCurrentThread,
+            func: shims::Handler::Sync(impls::GetCurrentThread),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetCurrentThreadId: Shim = Shim {
+        pub const GetCurrentThreadId: shims::Shim = shims::Shim {
             name: "GetCurrentThreadId",
-            func: impls::GetCurrentThreadId,
+            func: shims::Handler::Sync(impls::GetCurrentThreadId),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetEnvironmentStrings: Shim = Shim {
+        pub const GetEnvironmentStrings: shims::Shim = shims::Shim {
             name: "GetEnvironmentStrings",
-            func: impls::GetEnvironmentStrings,
+            func: shims::Handler::Sync(impls::GetEnvironmentStrings),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetEnvironmentStringsW: Shim = Shim {
+        pub const GetEnvironmentStringsW: shims::Shim = shims::Shim {
             name: "GetEnvironmentStringsW",
-            func: impls::GetEnvironmentStringsW,
+            func: shims::Handler::Sync(impls::GetEnvironmentStringsW),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetEnvironmentVariableA: Shim = Shim {
+        pub const GetEnvironmentVariableA: shims::Shim = shims::Shim {
             name: "GetEnvironmentVariableA",
-            func: impls::GetEnvironmentVariableA,
+            func: shims::Handler::Sync(impls::GetEnvironmentVariableA),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const GetEnvironmentVariableW: Shim = Shim {
+        pub const GetEnvironmentVariableW: shims::Shim = shims::Shim {
             name: "GetEnvironmentVariableW",
-            func: impls::GetEnvironmentVariableW,
+            func: shims::Handler::Sync(impls::GetEnvironmentVariableW),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const GetFileAttributesA: Shim = Shim {
+        pub const GetFileAttributesA: shims::Shim = shims::Shim {
             name: "GetFileAttributesA",
-            func: impls::GetFileAttributesA,
+            func: shims::Handler::Sync(impls::GetFileAttributesA),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetFileInformationByHandle: Shim = Shim {
+        pub const GetFileInformationByHandle: shims::Shim = shims::Shim {
             name: "GetFileInformationByHandle",
-            func: impls::GetFileInformationByHandle,
+            func: shims::Handler::Sync(impls::GetFileInformationByHandle),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetFileSize: Shim = Shim {
+        pub const GetFileSize: shims::Shim = shims::Shim {
             name: "GetFileSize",
-            func: impls::GetFileSize,
+            func: shims::Handler::Sync(impls::GetFileSize),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetFileTime: Shim = Shim {
+        pub const GetFileTime: shims::Shim = shims::Shim {
             name: "GetFileTime",
-            func: impls::GetFileTime,
+            func: shims::Handler::Sync(impls::GetFileTime),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const GetFileType: Shim = Shim {
+        pub const GetFileType: shims::Shim = shims::Shim {
             name: "GetFileType",
-            func: impls::GetFileType,
+            func: shims::Handler::Sync(impls::GetFileType),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetFullPathNameA: Shim = Shim {
+        pub const GetFullPathNameA: shims::Shim = shims::Shim {
             name: "GetFullPathNameA",
-            func: impls::GetFullPathNameA,
+            func: shims::Handler::Sync(impls::GetFullPathNameA),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const GetFullPathNameW: Shim = Shim {
+        pub const GetFullPathNameW: shims::Shim = shims::Shim {
             name: "GetFullPathNameW",
-            func: impls::GetFullPathNameW,
+            func: shims::Handler::Sync(impls::GetFullPathNameW),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const GetLastError: Shim = Shim {
+        pub const GetLastError: shims::Shim = shims::Shim {
             name: "GetLastError",
-            func: impls::GetLastError,
+            func: shims::Handler::Sync(impls::GetLastError),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetLocalTime: Shim = Shim {
+        pub const GetLocalTime: shims::Shim = shims::Shim {
             name: "GetLocalTime",
-            func: impls::GetLocalTime,
+            func: shims::Handler::Sync(impls::GetLocalTime),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetModuleFileNameA: Shim = Shim {
+        pub const GetModuleFileNameA: shims::Shim = shims::Shim {
             name: "GetModuleFileNameA",
-            func: impls::GetModuleFileNameA,
+            func: shims::Handler::Sync(impls::GetModuleFileNameA),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const GetModuleFileNameW: Shim = Shim {
+        pub const GetModuleFileNameW: shims::Shim = shims::Shim {
             name: "GetModuleFileNameW",
-            func: impls::GetModuleFileNameW,
+            func: shims::Handler::Sync(impls::GetModuleFileNameW),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const GetModuleHandleA: Shim = Shim {
+        pub const GetModuleHandleA: shims::Shim = shims::Shim {
             name: "GetModuleHandleA",
-            func: impls::GetModuleHandleA,
+            func: shims::Handler::Sync(impls::GetModuleHandleA),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetModuleHandleExW: Shim = Shim {
+        pub const GetModuleHandleExW: shims::Shim = shims::Shim {
             name: "GetModuleHandleExW",
-            func: impls::GetModuleHandleExW,
+            func: shims::Handler::Sync(impls::GetModuleHandleExW),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const GetModuleHandleW: Shim = Shim {
+        pub const GetModuleHandleW: shims::Shim = shims::Shim {
             name: "GetModuleHandleW",
-            func: impls::GetModuleHandleW,
+            func: shims::Handler::Sync(impls::GetModuleHandleW),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetPrivateProfileIntW: Shim = Shim {
+        pub const GetPrivateProfileIntW: shims::Shim = shims::Shim {
             name: "GetPrivateProfileIntW",
-            func: impls::GetPrivateProfileIntW,
+            func: shims::Handler::Sync(impls::GetPrivateProfileIntW),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const GetPrivateProfileStringW: Shim = Shim {
+        pub const GetPrivateProfileStringW: shims::Shim = shims::Shim {
             name: "GetPrivateProfileStringW",
-            func: impls::GetPrivateProfileStringW,
+            func: shims::Handler::Sync(impls::GetPrivateProfileStringW),
             stack_consumed: 24u32,
-            is_async: false,
         };
-        pub const GetProcAddress: Shim = Shim {
+        pub const GetProcAddress: shims::Shim = shims::Shim {
             name: "GetProcAddress",
-            func: impls::GetProcAddress,
+            func: shims::Handler::Sync(impls::GetProcAddress),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetProcessHeap: Shim = Shim {
+        pub const GetProcessHeap: shims::Shim = shims::Shim {
             name: "GetProcessHeap",
-            func: impls::GetProcessHeap,
+            func: shims::Handler::Sync(impls::GetProcessHeap),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetProfileIntW: Shim = Shim {
+        pub const GetProfileIntW: shims::Shim = shims::Shim {
             name: "GetProfileIntW",
-            func: impls::GetProfileIntW,
+            func: shims::Handler::Sync(impls::GetProfileIntW),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const GetProfileStringW: Shim = Shim {
+        pub const GetProfileStringW: shims::Shim = shims::Shim {
             name: "GetProfileStringW",
-            func: impls::GetProfileStringW,
+            func: shims::Handler::Sync(impls::GetProfileStringW),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const GetStartupInfoA: Shim = Shim {
+        pub const GetStartupInfoA: shims::Shim = shims::Shim {
             name: "GetStartupInfoA",
-            func: impls::GetStartupInfoA,
+            func: shims::Handler::Sync(impls::GetStartupInfoA),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetStartupInfoW: Shim = Shim {
+        pub const GetStartupInfoW: shims::Shim = shims::Shim {
             name: "GetStartupInfoW",
-            func: impls::GetStartupInfoW,
+            func: shims::Handler::Sync(impls::GetStartupInfoW),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetStdHandle: Shim = Shim {
+        pub const GetStdHandle: shims::Shim = shims::Shim {
             name: "GetStdHandle",
-            func: impls::GetStdHandle,
+            func: shims::Handler::Sync(impls::GetStdHandle),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetSystemDirectoryA: Shim = Shim {
+        pub const GetSystemDirectoryA: shims::Shim = shims::Shim {
             name: "GetSystemDirectoryA",
-            func: impls::GetSystemDirectoryA,
+            func: shims::Handler::Sync(impls::GetSystemDirectoryA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetSystemTime: Shim = Shim {
+        pub const GetSystemTime: shims::Shim = shims::Shim {
             name: "GetSystemTime",
-            func: impls::GetSystemTime,
+            func: shims::Handler::Sync(impls::GetSystemTime),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetSystemTimeAsFileTime: Shim = Shim {
+        pub const GetSystemTimeAsFileTime: shims::Shim = shims::Shim {
             name: "GetSystemTimeAsFileTime",
-            func: impls::GetSystemTimeAsFileTime,
+            func: shims::Handler::Sync(impls::GetSystemTimeAsFileTime),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetTickCount: Shim = Shim {
+        pub const GetTickCount: shims::Shim = shims::Shim {
             name: "GetTickCount",
-            func: impls::GetTickCount,
+            func: shims::Handler::Sync(impls::GetTickCount),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetTimeZoneInformation: Shim = Shim {
+        pub const GetTimeZoneInformation: shims::Shim = shims::Shim {
             name: "GetTimeZoneInformation",
-            func: impls::GetTimeZoneInformation,
+            func: shims::Handler::Sync(impls::GetTimeZoneInformation),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetVersion: Shim = Shim {
+        pub const GetVersion: shims::Shim = shims::Shim {
             name: "GetVersion",
-            func: impls::GetVersion,
+            func: shims::Handler::Sync(impls::GetVersion),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetVersionExA: Shim = Shim {
+        pub const GetVersionExA: shims::Shim = shims::Shim {
             name: "GetVersionExA",
-            func: impls::GetVersionExA,
+            func: shims::Handler::Sync(impls::GetVersionExA),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetWindowsDirectoryA: Shim = Shim {
+        pub const GetWindowsDirectoryA: shims::Shim = shims::Shim {
             name: "GetWindowsDirectoryA",
-            func: impls::GetWindowsDirectoryA,
+            func: shims::Handler::Sync(impls::GetWindowsDirectoryA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GlobalAlloc: Shim = Shim {
+        pub const GlobalAlloc: shims::Shim = shims::Shim {
             name: "GlobalAlloc",
-            func: impls::GlobalAlloc,
+            func: shims::Handler::Sync(impls::GlobalAlloc),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GlobalFlags: Shim = Shim {
+        pub const GlobalFlags: shims::Shim = shims::Shim {
             name: "GlobalFlags",
-            func: impls::GlobalFlags,
+            func: shims::Handler::Sync(impls::GlobalFlags),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GlobalFree: Shim = Shim {
+        pub const GlobalFree: shims::Shim = shims::Shim {
             name: "GlobalFree",
-            func: impls::GlobalFree,
+            func: shims::Handler::Sync(impls::GlobalFree),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GlobalReAlloc: Shim = Shim {
+        pub const GlobalReAlloc: shims::Shim = shims::Shim {
             name: "GlobalReAlloc",
-            func: impls::GlobalReAlloc,
+            func: shims::Handler::Sync(impls::GlobalReAlloc),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const HeapAlloc: Shim = Shim {
+        pub const HeapAlloc: shims::Shim = shims::Shim {
             name: "HeapAlloc",
-            func: impls::HeapAlloc,
+            func: shims::Handler::Sync(impls::HeapAlloc),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const HeapCreate: Shim = Shim {
+        pub const HeapCreate: shims::Shim = shims::Shim {
             name: "HeapCreate",
-            func: impls::HeapCreate,
+            func: shims::Handler::Sync(impls::HeapCreate),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const HeapDestroy: Shim = Shim {
+        pub const HeapDestroy: shims::Shim = shims::Shim {
             name: "HeapDestroy",
-            func: impls::HeapDestroy,
+            func: shims::Handler::Sync(impls::HeapDestroy),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const HeapFree: Shim = Shim {
+        pub const HeapFree: shims::Shim = shims::Shim {
             name: "HeapFree",
-            func: impls::HeapFree,
+            func: shims::Handler::Sync(impls::HeapFree),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const HeapReAlloc: Shim = Shim {
+        pub const HeapReAlloc: shims::Shim = shims::Shim {
             name: "HeapReAlloc",
-            func: impls::HeapReAlloc,
+            func: shims::Handler::Sync(impls::HeapReAlloc),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const HeapSetInformation: Shim = Shim {
+        pub const HeapSetInformation: shims::Shim = shims::Shim {
             name: "HeapSetInformation",
-            func: impls::HeapSetInformation,
+            func: shims::Handler::Sync(impls::HeapSetInformation),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const HeapSize: Shim = Shim {
+        pub const HeapSize: shims::Shim = shims::Shim {
             name: "HeapSize",
-            func: impls::HeapSize,
+            func: shims::Handler::Sync(impls::HeapSize),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const InitOnceBeginInitialize: Shim = Shim {
+        pub const InitOnceBeginInitialize: shims::Shim = shims::Shim {
             name: "InitOnceBeginInitialize",
-            func: impls::InitOnceBeginInitialize,
+            func: shims::Handler::Sync(impls::InitOnceBeginInitialize),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const InitOnceComplete: Shim = Shim {
+        pub const InitOnceComplete: shims::Shim = shims::Shim {
             name: "InitOnceComplete",
-            func: impls::InitOnceComplete,
+            func: shims::Handler::Sync(impls::InitOnceComplete),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const InitializeCriticalSection: Shim = Shim {
+        pub const InitializeCriticalSection: shims::Shim = shims::Shim {
             name: "InitializeCriticalSection",
-            func: impls::InitializeCriticalSection,
+            func: shims::Handler::Sync(impls::InitializeCriticalSection),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const InitializeCriticalSectionAndSpinCount: Shim = Shim {
+        pub const InitializeCriticalSectionAndSpinCount: shims::Shim = shims::Shim {
             name: "InitializeCriticalSectionAndSpinCount",
-            func: impls::InitializeCriticalSectionAndSpinCount,
+            func: shims::Handler::Sync(impls::InitializeCriticalSectionAndSpinCount),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const InitializeCriticalSectionEx: Shim = Shim {
+        pub const InitializeCriticalSectionEx: shims::Shim = shims::Shim {
             name: "InitializeCriticalSectionEx",
-            func: impls::InitializeCriticalSectionEx,
+            func: shims::Handler::Sync(impls::InitializeCriticalSectionEx),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const InitializeSListHead: Shim = Shim {
+        pub const InitializeSListHead: shims::Shim = shims::Shim {
             name: "InitializeSListHead",
-            func: impls::InitializeSListHead,
+            func: shims::Handler::Sync(impls::InitializeSListHead),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const InterlockedIncrement: Shim = Shim {
+        pub const InterlockedIncrement: shims::Shim = shims::Shim {
             name: "InterlockedIncrement",
-            func: impls::InterlockedIncrement,
+            func: shims::Handler::Sync(impls::InterlockedIncrement),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const IsBadReadPtr: Shim = Shim {
+        pub const IsBadReadPtr: shims::Shim = shims::Shim {
             name: "IsBadReadPtr",
-            func: impls::IsBadReadPtr,
+            func: shims::Handler::Sync(impls::IsBadReadPtr),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const IsBadWritePtr: Shim = Shim {
+        pub const IsBadWritePtr: shims::Shim = shims::Shim {
             name: "IsBadWritePtr",
-            func: impls::IsBadWritePtr,
+            func: shims::Handler::Sync(impls::IsBadWritePtr),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const IsDBCSLeadByte: Shim = Shim {
+        pub const IsDBCSLeadByte: shims::Shim = shims::Shim {
             name: "IsDBCSLeadByte",
-            func: impls::IsDBCSLeadByte,
+            func: shims::Handler::Sync(impls::IsDBCSLeadByte),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const IsDBCSLeadByteEx: Shim = Shim {
+        pub const IsDBCSLeadByteEx: shims::Shim = shims::Shim {
             name: "IsDBCSLeadByteEx",
-            func: impls::IsDBCSLeadByteEx,
+            func: shims::Handler::Sync(impls::IsDBCSLeadByteEx),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const IsDebuggerPresent: Shim = Shim {
+        pub const IsDebuggerPresent: shims::Shim = shims::Shim {
             name: "IsDebuggerPresent",
-            func: impls::IsDebuggerPresent,
+            func: shims::Handler::Sync(impls::IsDebuggerPresent),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const IsProcessorFeaturePresent: Shim = Shim {
+        pub const IsProcessorFeaturePresent: shims::Shim = shims::Shim {
             name: "IsProcessorFeaturePresent",
-            func: impls::IsProcessorFeaturePresent,
+            func: shims::Handler::Sync(impls::IsProcessorFeaturePresent),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const IsValidCodePage: Shim = Shim {
+        pub const IsValidCodePage: shims::Shim = shims::Shim {
             name: "IsValidCodePage",
-            func: impls::IsValidCodePage,
+            func: shims::Handler::Sync(impls::IsValidCodePage),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const LeaveCriticalSection: Shim = Shim {
+        pub const LeaveCriticalSection: shims::Shim = shims::Shim {
             name: "LeaveCriticalSection",
-            func: impls::LeaveCriticalSection,
+            func: shims::Handler::Sync(impls::LeaveCriticalSection),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const LoadLibraryA: Shim = Shim {
+        pub const LoadLibraryA: shims::Shim = shims::Shim {
             name: "LoadLibraryA",
-            func: impls::LoadLibraryA,
+            func: shims::Handler::Sync(impls::LoadLibraryA),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const LoadLibraryExW: Shim = Shim {
+        pub const LoadLibraryExW: shims::Shim = shims::Shim {
             name: "LoadLibraryExW",
-            func: impls::LoadLibraryExW,
+            func: shims::Handler::Sync(impls::LoadLibraryExW),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const LoadResource: Shim = Shim {
+        pub const LoadResource: shims::Shim = shims::Shim {
             name: "LoadResource",
-            func: impls::LoadResource,
+            func: shims::Handler::Sync(impls::LoadResource),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const LocalAlloc: Shim = Shim {
+        pub const LocalAlloc: shims::Shim = shims::Shim {
             name: "LocalAlloc",
-            func: impls::LocalAlloc,
+            func: shims::Handler::Sync(impls::LocalAlloc),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const LocalFree: Shim = Shim {
+        pub const LocalFree: shims::Shim = shims::Shim {
             name: "LocalFree",
-            func: impls::LocalFree,
+            func: shims::Handler::Sync(impls::LocalFree),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const LockResource: Shim = Shim {
+        pub const LockResource: shims::Shim = shims::Shim {
             name: "LockResource",
-            func: impls::LockResource,
+            func: shims::Handler::Sync(impls::LockResource),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const MulDiv: Shim = Shim {
+        pub const MulDiv: shims::Shim = shims::Shim {
             name: "MulDiv",
-            func: impls::MulDiv,
+            func: shims::Handler::Sync(impls::MulDiv),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const MultiByteToWideChar: Shim = Shim {
+        pub const MultiByteToWideChar: shims::Shim = shims::Shim {
             name: "MultiByteToWideChar",
-            func: impls::MultiByteToWideChar,
+            func: shims::Handler::Sync(impls::MultiByteToWideChar),
             stack_consumed: 24u32,
-            is_async: false,
         };
-        pub const NtCurrentTeb: Shim = Shim {
+        pub const NtCurrentTeb: shims::Shim = shims::Shim {
             name: "NtCurrentTeb",
-            func: impls::NtCurrentTeb,
+            func: shims::Handler::Sync(impls::NtCurrentTeb),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const OutputDebugStringA: Shim = Shim {
+        pub const OutputDebugStringA: shims::Shim = shims::Shim {
             name: "OutputDebugStringA",
-            func: impls::OutputDebugStringA,
+            func: shims::Handler::Sync(impls::OutputDebugStringA),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const QueryPerformanceCounter: Shim = Shim {
+        pub const QueryPerformanceCounter: shims::Shim = shims::Shim {
             name: "QueryPerformanceCounter",
-            func: impls::QueryPerformanceCounter,
+            func: shims::Handler::Sync(impls::QueryPerformanceCounter),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const QueryPerformanceFrequency: Shim = Shim {
+        pub const QueryPerformanceFrequency: shims::Shim = shims::Shim {
             name: "QueryPerformanceFrequency",
-            func: impls::QueryPerformanceFrequency,
+            func: shims::Handler::Sync(impls::QueryPerformanceFrequency),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const ReadFile: Shim = Shim {
+        pub const ReadFile: shims::Shim = shims::Shim {
             name: "ReadFile",
-            func: impls::ReadFile,
+            func: shims::Handler::Sync(impls::ReadFile),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const ReleaseSRWLockExclusive: Shim = Shim {
+        pub const ReleaseSRWLockExclusive: shims::Shim = shims::Shim {
             name: "ReleaseSRWLockExclusive",
-            func: impls::ReleaseSRWLockExclusive,
+            func: shims::Handler::Sync(impls::ReleaseSRWLockExclusive),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const ReleaseSRWLockShared: Shim = Shim {
+        pub const ReleaseSRWLockShared: shims::Shim = shims::Shim {
             name: "ReleaseSRWLockShared",
-            func: impls::ReleaseSRWLockShared,
+            func: shims::Handler::Sync(impls::ReleaseSRWLockShared),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const RemoveDirectoryA: Shim = Shim {
+        pub const RemoveDirectoryA: shims::Shim = shims::Shim {
             name: "RemoveDirectoryA",
-            func: impls::RemoveDirectoryA,
+            func: shims::Handler::Sync(impls::RemoveDirectoryA),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const SetConsoleCtrlHandler: Shim = Shim {
+        pub const SetConsoleCtrlHandler: shims::Shim = shims::Shim {
             name: "SetConsoleCtrlHandler",
-            func: impls::SetConsoleCtrlHandler,
+            func: shims::Handler::Sync(impls::SetConsoleCtrlHandler),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const SetEndOfFile: Shim = Shim {
+        pub const SetEndOfFile: shims::Shim = shims::Shim {
             name: "SetEndOfFile",
-            func: impls::SetEndOfFile,
+            func: shims::Handler::Sync(impls::SetEndOfFile),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const SetEvent: Shim = Shim {
+        pub const SetEvent: shims::Shim = shims::Shim {
             name: "SetEvent",
-            func: impls::SetEvent,
+            func: shims::Handler::Sync(impls::SetEvent),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const SetFileAttributesA: Shim = Shim {
+        pub const SetFileAttributesA: shims::Shim = shims::Shim {
             name: "SetFileAttributesA",
-            func: impls::SetFileAttributesA,
+            func: shims::Handler::Sync(impls::SetFileAttributesA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const SetFilePointer: Shim = Shim {
+        pub const SetFilePointer: shims::Shim = shims::Shim {
             name: "SetFilePointer",
-            func: impls::SetFilePointer,
+            func: shims::Handler::Sync(impls::SetFilePointer),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const SetFileTime: Shim = Shim {
+        pub const SetFileTime: shims::Shim = shims::Shim {
             name: "SetFileTime",
-            func: impls::SetFileTime,
+            func: shims::Handler::Sync(impls::SetFileTime),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const SetHandleCount: Shim = Shim {
+        pub const SetHandleCount: shims::Shim = shims::Shim {
             name: "SetHandleCount",
-            func: impls::SetHandleCount,
+            func: shims::Handler::Sync(impls::SetHandleCount),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const SetLastError: Shim = Shim {
+        pub const SetLastError: shims::Shim = shims::Shim {
             name: "SetLastError",
-            func: impls::SetLastError,
+            func: shims::Handler::Sync(impls::SetLastError),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const SetPriorityClass: Shim = Shim {
+        pub const SetPriorityClass: shims::Shim = shims::Shim {
             name: "SetPriorityClass",
-            func: impls::SetPriorityClass,
+            func: shims::Handler::Sync(impls::SetPriorityClass),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const SetStdHandle: Shim = Shim {
+        pub const SetStdHandle: shims::Shim = shims::Shim {
             name: "SetStdHandle",
-            func: impls::SetStdHandle,
+            func: shims::Handler::Sync(impls::SetStdHandle),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const SetThreadDescription: Shim = Shim {
+        pub const SetThreadDescription: shims::Shim = shims::Shim {
             name: "SetThreadDescription",
-            func: impls::SetThreadDescription,
+            func: shims::Handler::Sync(impls::SetThreadDescription),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const SetThreadPriority: Shim = Shim {
+        pub const SetThreadPriority: shims::Shim = shims::Shim {
             name: "SetThreadPriority",
-            func: impls::SetThreadPriority,
+            func: shims::Handler::Sync(impls::SetThreadPriority),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const SetThreadStackGuarantee: Shim = Shim {
+        pub const SetThreadStackGuarantee: shims::Shim = shims::Shim {
             name: "SetThreadStackGuarantee",
-            func: impls::SetThreadStackGuarantee,
+            func: shims::Handler::Sync(impls::SetThreadStackGuarantee),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const SetUnhandledExceptionFilter: Shim = Shim {
+        pub const SetUnhandledExceptionFilter: shims::Shim = shims::Shim {
             name: "SetUnhandledExceptionFilter",
-            func: impls::SetUnhandledExceptionFilter,
+            func: shims::Handler::Sync(impls::SetUnhandledExceptionFilter),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const Sleep: Shim = Shim {
+        pub const Sleep: shims::Shim = shims::Shim {
             name: "Sleep",
-            func: impls::Sleep,
+            func: shims::Handler::Async(impls::Sleep),
             stack_consumed: 4u32,
-            is_async: true,
         };
-        pub const SystemTimeToFileTime: Shim = Shim {
+        pub const SystemTimeToFileTime: shims::Shim = shims::Shim {
             name: "SystemTimeToFileTime",
-            func: impls::SystemTimeToFileTime,
+            func: shims::Handler::Sync(impls::SystemTimeToFileTime),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const TlsAlloc: Shim = Shim {
+        pub const TlsAlloc: shims::Shim = shims::Shim {
             name: "TlsAlloc",
-            func: impls::TlsAlloc,
+            func: shims::Handler::Sync(impls::TlsAlloc),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const TlsFree: Shim = Shim {
+        pub const TlsFree: shims::Shim = shims::Shim {
             name: "TlsFree",
-            func: impls::TlsFree,
+            func: shims::Handler::Sync(impls::TlsFree),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const TlsGetValue: Shim = Shim {
+        pub const TlsGetValue: shims::Shim = shims::Shim {
             name: "TlsGetValue",
-            func: impls::TlsGetValue,
+            func: shims::Handler::Sync(impls::TlsGetValue),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const TlsSetValue: Shim = Shim {
+        pub const TlsSetValue: shims::Shim = shims::Shim {
             name: "TlsSetValue",
-            func: impls::TlsSetValue,
+            func: shims::Handler::Sync(impls::TlsSetValue),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const TryAcquireSRWLockExclusive: Shim = Shim {
+        pub const TryAcquireSRWLockExclusive: shims::Shim = shims::Shim {
             name: "TryAcquireSRWLockExclusive",
-            func: impls::TryAcquireSRWLockExclusive,
+            func: shims::Handler::Sync(impls::TryAcquireSRWLockExclusive),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const UnhandledExceptionFilter: Shim = Shim {
+        pub const UnhandledExceptionFilter: shims::Shim = shims::Shim {
             name: "UnhandledExceptionFilter",
-            func: impls::UnhandledExceptionFilter,
+            func: shims::Handler::Sync(impls::UnhandledExceptionFilter),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const VirtualAlloc: Shim = Shim {
+        pub const VirtualAlloc: shims::Shim = shims::Shim {
             name: "VirtualAlloc",
-            func: impls::VirtualAlloc,
+            func: shims::Handler::Sync(impls::VirtualAlloc),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const VirtualFree: Shim = Shim {
+        pub const VirtualFree: shims::Shim = shims::Shim {
             name: "VirtualFree",
-            func: impls::VirtualFree,
+            func: shims::Handler::Sync(impls::VirtualFree),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const VirtualProtect: Shim = Shim {
+        pub const VirtualProtect: shims::Shim = shims::Shim {
             name: "VirtualProtect",
-            func: impls::VirtualProtect,
+            func: shims::Handler::Sync(impls::VirtualProtect),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const VirtualQuery: Shim = Shim {
+        pub const VirtualQuery: shims::Shim = shims::Shim {
             name: "VirtualQuery",
-            func: impls::VirtualQuery,
+            func: shims::Handler::Sync(impls::VirtualQuery),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const WaitForSingleObject: Shim = Shim {
+        pub const WaitForSingleObject: shims::Shim = shims::Shim {
             name: "WaitForSingleObject",
-            func: impls::WaitForSingleObject,
+            func: shims::Handler::Sync(impls::WaitForSingleObject),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const WriteConsoleA: Shim = Shim {
+        pub const WriteConsoleA: shims::Shim = shims::Shim {
             name: "WriteConsoleA",
-            func: impls::WriteConsoleA,
+            func: shims::Handler::Sync(impls::WriteConsoleA),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const WriteConsoleW: Shim = Shim {
+        pub const WriteConsoleW: shims::Shim = shims::Shim {
             name: "WriteConsoleW",
-            func: impls::WriteConsoleW,
+            func: shims::Handler::Sync(impls::WriteConsoleW),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const WriteFile: Shim = Shim {
+        pub const WriteFile: shims::Shim = shims::Shim {
             name: "WriteFile",
-            func: impls::WriteFile,
+            func: shims::Handler::Sync(impls::WriteFile),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const lstrcmpiA: Shim = Shim {
+        pub const lstrcmpiA: shims::Shim = shims::Shim {
             name: "lstrcmpiA",
-            func: impls::lstrcmpiA,
+            func: shims::Handler::Sync(impls::lstrcmpiA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const lstrcpyA: Shim = Shim {
+        pub const lstrcpyA: shims::Shim = shims::Shim {
             name: "lstrcpyA",
-            func: impls::lstrcpyA,
+            func: shims::Handler::Sync(impls::lstrcpyA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const lstrcpyW: Shim = Shim {
+        pub const lstrcpyW: shims::Shim = shims::Shim {
             name: "lstrcpyW",
-            func: impls::lstrcpyW,
+            func: shims::Handler::Sync(impls::lstrcpyW),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const lstrlenA: Shim = Shim {
+        pub const lstrlenA: shims::Shim = shims::Shim {
             name: "lstrlenA",
-            func: impls::lstrlenA,
+            func: shims::Handler::Sync(impls::lstrlenA),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const lstrlenW: Shim = Shim {
+        pub const lstrlenW: shims::Shim = shims::Shim {
             name: "lstrlenW",
-            func: impls::lstrlenW,
+            func: shims::Handler::Sync(impls::lstrlenW),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const retrowin32_main: Shim = Shim {
+        pub const retrowin32_main: shims::Shim = shims::Shim {
             name: "retrowin32_main",
-            func: impls::retrowin32_main,
+            func: shims::Handler::Async(impls::retrowin32_main),
             stack_consumed: 4u32,
-            is_async: true,
         };
-        pub const retrowin32_thread_main: Shim = Shim {
+        pub const retrowin32_thread_main: shims::Shim = shims::Shim {
             name: "retrowin32_thread_main",
-            func: impls::retrowin32_thread_main,
+            func: shims::Handler::Async(impls::retrowin32_thread_main),
             stack_consumed: 8u32,
-            is_async: true,
         };
     }
     const EXPORTS: [Symbol; 148usize] = [
@@ -3805,12 +3551,11 @@ pub mod ntdll {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const NtReadFile: Shim = Shim {
+        use crate::shims;
+        pub const NtReadFile: shims::Shim = shims::Shim {
             name: "NtReadFile",
-            func: impls::NtReadFile,
+            func: shims::Handler::Sync(impls::NtReadFile),
             stack_consumed: 36u32,
-            is_async: false,
         };
     }
     const EXPORTS: [Symbol; 1usize] = [Symbol {
@@ -3835,7 +3580,7 @@ pub mod ole32 {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
+        use crate::shims;
     }
     const EXPORTS: [Symbol; 0usize] = [];
     pub const DLL: BuiltinDLL = BuiltinDLL {
@@ -3856,7 +3601,7 @@ pub mod oleaut32 {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
+        use crate::shims;
     }
     const EXPORTS: [Symbol; 0usize] = [];
     pub const DLL: BuiltinDLL = BuiltinDLL {
@@ -3874,44 +3619,29 @@ pub mod retrowin32_test {
         };
         use memory::Extensions;
         use winapi::retrowin32_test::*;
-        pub unsafe fn retrowin32_test_callback1(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn retrowin32_test_callback1(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let func = <u32>::from_stack(mem, esp + 4u32);
             let data = <u32>::from_stack(mem, esp + 8u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result =
-                        winapi::retrowin32_test::retrowin32_test_callback1(machine, func, data)
-                            .await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 8u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::retrowin32_test::retrowin32_test_callback1(
-                    machine, func, data
-                ));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::retrowin32_test::retrowin32_test_callback1(machine, func, data)
+                    .await
+                    .to_raw()
+            })
         }
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const retrowin32_test_callback1: Shim = Shim {
+        use crate::shims;
+        pub const retrowin32_test_callback1: shims::Shim = shims::Shim {
             name: "retrowin32_test_callback1",
-            func: impls::retrowin32_test_callback1,
+            func: shims::Handler::Async(impls::retrowin32_test_callback1),
             stack_consumed: 8u32,
-            is_async: true,
         };
     }
     const EXPORTS: [Symbol; 1usize] = [Symbol {
@@ -3965,55 +3695,35 @@ pub mod ucrtbase {
             let mem = machine.mem().detach();
             winapi::ucrtbase::_get_initial_narrow_environment(machine).to_raw()
         }
-        pub unsafe fn _initterm(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn _initterm(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let start = <u32>::from_stack(mem, esp + 4u32);
             let end = <u32>::from_stack(mem, esp + 8u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::ucrtbase::_initterm(machine, start, end).await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 0u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::ucrtbase::_initterm(machine, start, end));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::ucrtbase::_initterm(machine, start, end)
+                    .await
+                    .to_raw()
+            })
         }
-        pub unsafe fn _initterm_e(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn _initterm_e(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let start = <u32>::from_stack(mem, esp + 4u32);
             let end = <u32>::from_stack(mem, esp + 8u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::ucrtbase::_initterm_e(machine, start, end).await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 0u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::ucrtbase::_initterm_e(machine, start, end));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::ucrtbase::_initterm_e(machine, start, end)
+                    .await
+                    .to_raw()
+            })
         }
         pub unsafe fn _lock(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -4043,90 +3753,76 @@ pub mod ucrtbase {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const __dllonexit: Shim = Shim {
+        use crate::shims;
+        pub const __dllonexit: shims::Shim = shims::Shim {
             name: "__dllonexit",
-            func: impls::__dllonexit,
+            func: shims::Handler::Sync(impls::__dllonexit),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const __p___argc: Shim = Shim {
+        pub const __p___argc: shims::Shim = shims::Shim {
             name: "__p___argc",
-            func: impls::__p___argc,
+            func: shims::Handler::Sync(impls::__p___argc),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const __p___argv: Shim = Shim {
+        pub const __p___argv: shims::Shim = shims::Shim {
             name: "__p___argv",
-            func: impls::__p___argv,
+            func: shims::Handler::Sync(impls::__p___argv),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const __p__commode: Shim = Shim {
+        pub const __p__commode: shims::Shim = shims::Shim {
             name: "__p__commode",
-            func: impls::__p__commode,
+            func: shims::Handler::Sync(impls::__p__commode),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const __p__fmode: Shim = Shim {
+        pub const __p__fmode: shims::Shim = shims::Shim {
             name: "__p__fmode",
-            func: impls::__p__fmode,
+            func: shims::Handler::Sync(impls::__p__fmode),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const __set_app_type: Shim = Shim {
+        pub const __set_app_type: shims::Shim = shims::Shim {
             name: "__set_app_type",
-            func: impls::__set_app_type,
+            func: shims::Handler::Sync(impls::__set_app_type),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const _get_initial_narrow_environment: Shim = Shim {
+        pub const _get_initial_narrow_environment: shims::Shim = shims::Shim {
             name: "_get_initial_narrow_environment",
-            func: impls::_get_initial_narrow_environment,
+            func: shims::Handler::Sync(impls::_get_initial_narrow_environment),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const _initterm: Shim = Shim {
+        pub const _initterm: shims::Shim = shims::Shim {
             name: "_initterm",
-            func: impls::_initterm,
+            func: shims::Handler::Async(impls::_initterm),
             stack_consumed: 0u32,
-            is_async: true,
         };
-        pub const _initterm_e: Shim = Shim {
+        pub const _initterm_e: shims::Shim = shims::Shim {
             name: "_initterm_e",
-            func: impls::_initterm_e,
+            func: shims::Handler::Async(impls::_initterm_e),
             stack_consumed: 0u32,
-            is_async: true,
         };
-        pub const _lock: Shim = Shim {
+        pub const _lock: shims::Shim = shims::Shim {
             name: "_lock",
-            func: impls::_lock,
+            func: shims::Handler::Sync(impls::_lock),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const _unlock: Shim = Shim {
+        pub const _unlock: shims::Shim = shims::Shim {
             name: "_unlock",
-            func: impls::_unlock,
+            func: shims::Handler::Sync(impls::_unlock),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const exit: Shim = Shim {
+        pub const exit: shims::Shim = shims::Shim {
             name: "exit",
-            func: impls::exit,
+            func: shims::Handler::Sync(impls::exit),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const free: Shim = Shim {
+        pub const free: shims::Shim = shims::Shim {
             name: "free",
-            func: impls::free,
+            func: shims::Handler::Sync(impls::free),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const malloc: Shim = Shim {
+        pub const malloc: shims::Shim = shims::Shim {
             name: "malloc",
-            func: impls::malloc,
+            func: shims::Handler::Sync(impls::malloc),
             stack_consumed: 0u32,
-            is_async: false,
         };
     }
     const EXPORTS: [Symbol; 14usize] = [
@@ -4232,30 +3928,26 @@ pub mod vcruntime140 {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const _CxxThrowException: Shim = Shim {
+        use crate::shims;
+        pub const _CxxThrowException: shims::Shim = shims::Shim {
             name: "_CxxThrowException",
-            func: impls::_CxxThrowException,
+            func: shims::Handler::Sync(impls::_CxxThrowException),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const memcmp: Shim = Shim {
+        pub const memcmp: shims::Shim = shims::Shim {
             name: "memcmp",
-            func: impls::memcmp,
+            func: shims::Handler::Sync(impls::memcmp),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const memcpy: Shim = Shim {
+        pub const memcpy: shims::Shim = shims::Shim {
             name: "memcpy",
-            func: impls::memcpy,
+            func: shims::Handler::Sync(impls::memcpy),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const memset: Shim = Shim {
+        pub const memset: shims::Shim = shims::Shim {
             name: "memset",
-            func: impls::memset,
+            func: shims::Handler::Sync(impls::memset),
             stack_consumed: 0u32,
-            is_async: false,
         };
     }
     const EXPORTS: [Symbol; 4usize] = [
@@ -4300,12 +3992,11 @@ pub mod version {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const GetFileVersionInfoSizeA: Shim = Shim {
+        use crate::shims;
+        pub const GetFileVersionInfoSizeA: shims::Shim = shims::Shim {
             name: "GetFileVersionInfoSizeA",
-            func: impls::GetFileVersionInfoSizeA,
+            func: shims::Handler::Sync(impls::GetFileVersionInfoSizeA),
             stack_consumed: 8u32,
-            is_async: false,
         };
     }
     const EXPORTS: [Symbol; 1usize] = [Symbol {
@@ -4383,7 +4074,10 @@ pub mod user32 {
             )
             .to_raw()
         }
-        pub unsafe fn CreateWindowExA(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn CreateWindowExA(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let dwExStyle = <Result<WindowStyleEx, u32>>::from_stack(mem, esp + 4u32);
             let lpClassName = <CreateWindowClassName<'_, str>>::from_stack(mem, esp + 8u32);
@@ -4397,39 +4091,10 @@ pub mod user32 {
             let hMenu = <u32>::from_stack(mem, esp + 40u32);
             let hInstance = <u32>::from_stack(mem, esp + 44u32);
             let lpParam = <u32>::from_stack(mem, esp + 48u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::user32::CreateWindowExA(
-                        machine,
-                        dwExStyle,
-                        lpClassName,
-                        lpWindowName,
-                        dwStyle,
-                        X,
-                        Y,
-                        nWidth,
-                        nHeight,
-                        hWndParent,
-                        hMenu,
-                        hInstance,
-                        lpParam,
-                    )
-                    .await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 48u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::user32::CreateWindowExA(
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::user32::CreateWindowExA(
                     machine,
                     dwExStyle,
                     lpClassName,
@@ -4442,12 +4107,16 @@ pub mod user32 {
                     hWndParent,
                     hMenu,
                     hInstance,
-                    lpParam
-                ));
-                crate::shims::call_sync(pin).to_raw()
-            }
+                    lpParam,
+                )
+                .await
+                .to_raw()
+            })
         }
-        pub unsafe fn CreateWindowExW(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn CreateWindowExW(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let dwExStyle = <Result<WindowStyleEx, u32>>::from_stack(mem, esp + 4u32);
             let lpClassName = <CreateWindowClassName<'_, Str16>>::from_stack(mem, esp + 8u32);
@@ -4461,39 +4130,10 @@ pub mod user32 {
             let hMenu = <u32>::from_stack(mem, esp + 40u32);
             let hInstance = <u32>::from_stack(mem, esp + 44u32);
             let lpParam = <u32>::from_stack(mem, esp + 48u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::user32::CreateWindowExW(
-                        machine,
-                        dwExStyle,
-                        lpClassName,
-                        lpWindowName,
-                        dwStyle,
-                        X,
-                        Y,
-                        nWidth,
-                        nHeight,
-                        hWndParent,
-                        hMenu,
-                        hInstance,
-                        lpParam,
-                    )
-                    .await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 48u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::user32::CreateWindowExW(
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::user32::CreateWindowExW(
                     machine,
                     dwExStyle,
                     lpClassName,
@@ -4506,70 +4146,45 @@ pub mod user32 {
                     hWndParent,
                     hMenu,
                     hInstance,
-                    lpParam
-                ));
-                crate::shims::call_sync(pin).to_raw()
-            }
+                    lpParam,
+                )
+                .await
+                .to_raw()
+            })
         }
-        pub unsafe fn DefWindowProcA(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn DefWindowProcA(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let hWnd = <HWND>::from_stack(mem, esp + 4u32);
             let msg = <Result<WM, u32>>::from_stack(mem, esp + 8u32);
             let wParam = <u32>::from_stack(mem, esp + 12u32);
             let lParam = <u32>::from_stack(mem, esp + 16u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result =
-                        winapi::user32::DefWindowProcA(machine, hWnd, msg, wParam, lParam).await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 16u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::user32::DefWindowProcA(
-                    machine, hWnd, msg, wParam, lParam
-                ));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::user32::DefWindowProcA(machine, hWnd, msg, wParam, lParam)
+                    .await
+                    .to_raw()
+            })
         }
-        pub unsafe fn DefWindowProcW(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn DefWindowProcW(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let hWnd = <HWND>::from_stack(mem, esp + 4u32);
             let msg = <Result<WM, u32>>::from_stack(mem, esp + 8u32);
             let wParam = <u32>::from_stack(mem, esp + 12u32);
             let lParam = <u32>::from_stack(mem, esp + 16u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result =
-                        winapi::user32::DefWindowProcW(machine, hWnd, msg, wParam, lParam).await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 16u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::user32::DefWindowProcW(
-                    machine, hWnd, msg, wParam, lParam
-                ));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::user32::DefWindowProcW(machine, hWnd, msg, wParam, lParam)
+                    .await
+                    .to_raw()
+            })
         }
         pub unsafe fn DestroyWindow(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -4610,53 +4225,33 @@ pub mod user32 {
             )
             .to_raw()
         }
-        pub unsafe fn DispatchMessageA(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn DispatchMessageA(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let lpMsg = <Option<&MSG>>::from_stack(mem, esp + 4u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::user32::DispatchMessageA(machine, lpMsg).await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 4u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::user32::DispatchMessageA(machine, lpMsg));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::user32::DispatchMessageA(machine, lpMsg)
+                    .await
+                    .to_raw()
+            })
         }
-        pub unsafe fn DispatchMessageW(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn DispatchMessageW(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let lpMsg = <Option<&MSG>>::from_stack(mem, esp + 4u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::user32::DispatchMessageW(machine, lpMsg).await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 4u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::user32::DispatchMessageW(machine, lpMsg));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::user32::DispatchMessageW(machine, lpMsg)
+                    .await
+                    .to_raw()
+            })
         }
         pub unsafe fn DrawTextW(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -4729,85 +4324,39 @@ pub mod user32 {
             let mem = machine.mem().detach();
             winapi::user32::GetLastActivePopup(machine).to_raw()
         }
-        pub unsafe fn GetMessageA(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn GetMessageA(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let lpMsg = <Option<&mut MSG>>::from_stack(mem, esp + 4u32);
             let hWnd = <HWND>::from_stack(mem, esp + 8u32);
             let wMsgFilterMin = <u32>::from_stack(mem, esp + 12u32);
             let wMsgFilterMax = <u32>::from_stack(mem, esp + 16u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::user32::GetMessageA(
-                        machine,
-                        lpMsg,
-                        hWnd,
-                        wMsgFilterMin,
-                        wMsgFilterMax,
-                    )
-                    .await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 16u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::user32::GetMessageA(
-                    machine,
-                    lpMsg,
-                    hWnd,
-                    wMsgFilterMin,
-                    wMsgFilterMax
-                ));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::user32::GetMessageA(machine, lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax)
+                    .await
+                    .to_raw()
+            })
         }
-        pub unsafe fn GetMessageW(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn GetMessageW(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let lpMsg = <Option<&mut MSG>>::from_stack(mem, esp + 4u32);
             let hWnd = <HWND>::from_stack(mem, esp + 8u32);
             let wMsgFilterMin = <u32>::from_stack(mem, esp + 12u32);
             let wMsgFilterMax = <u32>::from_stack(mem, esp + 16u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::user32::GetMessageW(
-                        machine,
-                        lpMsg,
-                        hWnd,
-                        wMsgFilterMin,
-                        wMsgFilterMax,
-                    )
-                    .await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 16u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::user32::GetMessageW(
-                    machine,
-                    lpMsg,
-                    hWnd,
-                    wMsgFilterMin,
-                    wMsgFilterMax
-                ));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::user32::GetMessageW(machine, lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax)
+                    .await
+                    .to_raw()
+            })
         }
         pub unsafe fn GetSystemMenu(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -5078,35 +4627,22 @@ pub mod user32 {
             let hdc = <HDC>::from_stack(mem, esp + 8u32);
             winapi::user32::ReleaseDC(machine, hwnd, hdc).to_raw()
         }
-        pub unsafe fn SendMessageA(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn SendMessageA(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let hWnd = <HWND>::from_stack(mem, esp + 4u32);
             let Msg = <Result<WM, u32>>::from_stack(mem, esp + 8u32);
             let wParam = <u32>::from_stack(mem, esp + 12u32);
             let lParam = <u32>::from_stack(mem, esp + 16u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result =
-                        winapi::user32::SendMessageA(machine, hWnd, Msg, wParam, lParam).await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 16u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::user32::SendMessageA(
-                    machine, hWnd, Msg, wParam, lParam
-                ));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::user32::SendMessageA(machine, hWnd, Msg, wParam, lParam)
+                    .await
+                    .to_raw()
+            })
         }
         pub unsafe fn SetCapture(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -5156,7 +4692,10 @@ pub mod user32 {
             let lpTimerFunc = <u32>::from_stack(mem, esp + 16u32);
             winapi::user32::SetTimer(machine, hWnd, nIDEvent, uElapse, lpTimerFunc).to_raw()
         }
-        pub unsafe fn SetWindowPos(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn SetWindowPos(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let hWnd = <HWND>::from_stack(mem, esp + 4u32);
             let hWndInsertAfter = <HWND>::from_stack(mem, esp + 8u32);
@@ -5165,45 +4704,13 @@ pub mod user32 {
             let cx = <i32>::from_stack(mem, esp + 20u32);
             let cy = <i32>::from_stack(mem, esp + 24u32);
             let uFlags = <Result<SWP, u32>>::from_stack(mem, esp + 28u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::user32::SetWindowPos(
-                        machine,
-                        hWnd,
-                        hWndInsertAfter,
-                        X,
-                        Y,
-                        cx,
-                        cy,
-                        uFlags,
-                    )
-                    .await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 28u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::user32::SetWindowPos(
-                    machine,
-                    hWnd,
-                    hWndInsertAfter,
-                    X,
-                    Y,
-                    cx,
-                    cy,
-                    uFlags
-                ));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::user32::SetWindowPos(machine, hWnd, hWndInsertAfter, X, Y, cx, cy, uFlags)
+                    .await
+                    .to_raw()
+            })
         }
         pub unsafe fn SetWindowTextA(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -5216,30 +4723,20 @@ pub mod user32 {
             let bShow = <bool>::from_stack(mem, esp + 4u32);
             winapi::user32::ShowCursor(machine, bShow).to_raw()
         }
-        pub unsafe fn ShowWindow(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn ShowWindow(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let hWnd = <HWND>::from_stack(mem, esp + 4u32);
             let nCmdShow = <Result<SW, u32>>::from_stack(mem, esp + 8u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::user32::ShowWindow(machine, hWnd, nCmdShow).await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 8u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::user32::ShowWindow(machine, hWnd, nCmdShow));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::user32::ShowWindow(machine, hWnd, nCmdShow)
+                    .await
+                    .to_raw()
+            })
         }
         pub unsafe fn TranslateAcceleratorW(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -5253,29 +4750,17 @@ pub mod user32 {
             let lpMsg = <Option<&MSG>>::from_stack(mem, esp + 4u32);
             winapi::user32::TranslateMessage(machine, lpMsg).to_raw()
         }
-        pub unsafe fn UpdateWindow(machine: &mut Machine, esp: u32) -> u32 {
+        pub unsafe fn UpdateWindow(
+            machine: &mut Machine,
+            esp: u32,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = u32>>> {
             let mem = machine.mem().detach();
             let hWnd = <HWND>::from_stack(mem, esp + 4u32);
-            #[cfg(feature = "x86-emu")]
-            {
-                let m: *mut Machine = machine;
-                let result = async move {
-                    use memory::Extensions;
-                    let machine = unsafe { &mut *m };
-                    let result = winapi::user32::UpdateWindow(machine, hWnd).await;
-                    let regs = &mut machine.emu.x86.cpu_mut().regs;
-                    regs.eip = machine.emu.memory.mem().get_pod::<u32>(esp);
-                    *regs.get32_mut(x86::Register::ESP) += 4u32 + 4;
-                    regs.set32(x86::Register::EAX, result.to_raw());
-                };
-                machine.emu.x86.cpu_mut().call_async(Box::pin(result));
-                0
-            }
-            #[cfg(any(feature = "x86-64", feature = "x86-unicorn"))]
-            {
-                let pin = std::pin::pin!(winapi::user32::UpdateWindow(machine, hWnd));
-                crate::shims::call_sync(pin).to_raw()
-            }
+            let machine: *mut Machine = machine;
+            Box::pin(async move {
+                let machine = unsafe { &mut *machine };
+                winapi::user32::UpdateWindow(machine, hWnd).await.to_raw()
+            })
         }
         pub unsafe fn ValidateRect(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
@@ -5297,528 +4782,441 @@ pub mod user32 {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const AdjustWindowRect: Shim = Shim {
+        use crate::shims;
+        pub const AdjustWindowRect: shims::Shim = shims::Shim {
             name: "AdjustWindowRect",
-            func: impls::AdjustWindowRect,
+            func: shims::Handler::Sync(impls::AdjustWindowRect),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const AdjustWindowRectEx: Shim = Shim {
+        pub const AdjustWindowRectEx: shims::Shim = shims::Shim {
             name: "AdjustWindowRectEx",
-            func: impls::AdjustWindowRectEx,
+            func: shims::Handler::Sync(impls::AdjustWindowRectEx),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const AppendMenuA: Shim = Shim {
+        pub const AppendMenuA: shims::Shim = shims::Shim {
             name: "AppendMenuA",
-            func: impls::AppendMenuA,
+            func: shims::Handler::Sync(impls::AppendMenuA),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const BeginPaint: Shim = Shim {
+        pub const BeginPaint: shims::Shim = shims::Shim {
             name: "BeginPaint",
-            func: impls::BeginPaint,
+            func: shims::Handler::Sync(impls::BeginPaint),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const CheckMenuItem: Shim = Shim {
+        pub const CheckMenuItem: shims::Shim = shims::Shim {
             name: "CheckMenuItem",
-            func: impls::CheckMenuItem,
+            func: shims::Handler::Sync(impls::CheckMenuItem),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const ClientToScreen: Shim = Shim {
+        pub const ClientToScreen: shims::Shim = shims::Shim {
             name: "ClientToScreen",
-            func: impls::ClientToScreen,
+            func: shims::Handler::Sync(impls::ClientToScreen),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const CreateCursor: Shim = Shim {
+        pub const CreateCursor: shims::Shim = shims::Shim {
             name: "CreateCursor",
-            func: impls::CreateCursor,
+            func: shims::Handler::Sync(impls::CreateCursor),
             stack_consumed: 28u32,
-            is_async: false,
         };
-        pub const CreateWindowExA: Shim = Shim {
+        pub const CreateWindowExA: shims::Shim = shims::Shim {
             name: "CreateWindowExA",
-            func: impls::CreateWindowExA,
+            func: shims::Handler::Async(impls::CreateWindowExA),
             stack_consumed: 48u32,
-            is_async: true,
         };
-        pub const CreateWindowExW: Shim = Shim {
+        pub const CreateWindowExW: shims::Shim = shims::Shim {
             name: "CreateWindowExW",
-            func: impls::CreateWindowExW,
+            func: shims::Handler::Async(impls::CreateWindowExW),
             stack_consumed: 48u32,
-            is_async: true,
         };
-        pub const DefWindowProcA: Shim = Shim {
+        pub const DefWindowProcA: shims::Shim = shims::Shim {
             name: "DefWindowProcA",
-            func: impls::DefWindowProcA,
+            func: shims::Handler::Async(impls::DefWindowProcA),
             stack_consumed: 16u32,
-            is_async: true,
         };
-        pub const DefWindowProcW: Shim = Shim {
+        pub const DefWindowProcW: shims::Shim = shims::Shim {
             name: "DefWindowProcW",
-            func: impls::DefWindowProcW,
+            func: shims::Handler::Async(impls::DefWindowProcW),
             stack_consumed: 16u32,
-            is_async: true,
         };
-        pub const DestroyWindow: Shim = Shim {
+        pub const DestroyWindow: shims::Shim = shims::Shim {
             name: "DestroyWindow",
-            func: impls::DestroyWindow,
+            func: shims::Handler::Sync(impls::DestroyWindow),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const DialogBoxIndirectParamA: Shim = Shim {
+        pub const DialogBoxIndirectParamA: shims::Shim = shims::Shim {
             name: "DialogBoxIndirectParamA",
-            func: impls::DialogBoxIndirectParamA,
+            func: shims::Handler::Sync(impls::DialogBoxIndirectParamA),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const DialogBoxParamA: Shim = Shim {
+        pub const DialogBoxParamA: shims::Shim = shims::Shim {
             name: "DialogBoxParamA",
-            func: impls::DialogBoxParamA,
+            func: shims::Handler::Sync(impls::DialogBoxParamA),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const DispatchMessageA: Shim = Shim {
+        pub const DispatchMessageA: shims::Shim = shims::Shim {
             name: "DispatchMessageA",
-            func: impls::DispatchMessageA,
+            func: shims::Handler::Async(impls::DispatchMessageA),
             stack_consumed: 4u32,
-            is_async: true,
         };
-        pub const DispatchMessageW: Shim = Shim {
+        pub const DispatchMessageW: shims::Shim = shims::Shim {
             name: "DispatchMessageW",
-            func: impls::DispatchMessageW,
+            func: shims::Handler::Async(impls::DispatchMessageW),
             stack_consumed: 4u32,
-            is_async: true,
         };
-        pub const DrawTextW: Shim = Shim {
+        pub const DrawTextW: shims::Shim = shims::Shim {
             name: "DrawTextW",
-            func: impls::DrawTextW,
+            func: shims::Handler::Sync(impls::DrawTextW),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const EndPaint: Shim = Shim {
+        pub const EndPaint: shims::Shim = shims::Shim {
             name: "EndPaint",
-            func: impls::EndPaint,
+            func: shims::Handler::Sync(impls::EndPaint),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const FillRect: Shim = Shim {
+        pub const FillRect: shims::Shim = shims::Shim {
             name: "FillRect",
-            func: impls::FillRect,
+            func: shims::Handler::Sync(impls::FillRect),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const FindWindowA: Shim = Shim {
+        pub const FindWindowA: shims::Shim = shims::Shim {
             name: "FindWindowA",
-            func: impls::FindWindowA,
+            func: shims::Handler::Sync(impls::FindWindowA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const FrameRect: Shim = Shim {
+        pub const FrameRect: shims::Shim = shims::Shim {
             name: "FrameRect",
-            func: impls::FrameRect,
+            func: shims::Handler::Sync(impls::FrameRect),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const GetActiveWindow: Shim = Shim {
+        pub const GetActiveWindow: shims::Shim = shims::Shim {
             name: "GetActiveWindow",
-            func: impls::GetActiveWindow,
+            func: shims::Handler::Sync(impls::GetActiveWindow),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetClientRect: Shim = Shim {
+        pub const GetClientRect: shims::Shim = shims::Shim {
             name: "GetClientRect",
-            func: impls::GetClientRect,
+            func: shims::Handler::Sync(impls::GetClientRect),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetDC: Shim = Shim {
+        pub const GetDC: shims::Shim = shims::Shim {
             name: "GetDC",
-            func: impls::GetDC,
+            func: shims::Handler::Sync(impls::GetDC),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetDesktopWindow: Shim = Shim {
+        pub const GetDesktopWindow: shims::Shim = shims::Shim {
             name: "GetDesktopWindow",
-            func: impls::GetDesktopWindow,
+            func: shims::Handler::Sync(impls::GetDesktopWindow),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetFocus: Shim = Shim {
+        pub const GetFocus: shims::Shim = shims::Shim {
             name: "GetFocus",
-            func: impls::GetFocus,
+            func: shims::Handler::Sync(impls::GetFocus),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetForegroundWindow: Shim = Shim {
+        pub const GetForegroundWindow: shims::Shim = shims::Shim {
             name: "GetForegroundWindow",
-            func: impls::GetForegroundWindow,
+            func: shims::Handler::Sync(impls::GetForegroundWindow),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetKeyState: Shim = Shim {
+        pub const GetKeyState: shims::Shim = shims::Shim {
             name: "GetKeyState",
-            func: impls::GetKeyState,
+            func: shims::Handler::Sync(impls::GetKeyState),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetLastActivePopup: Shim = Shim {
+        pub const GetLastActivePopup: shims::Shim = shims::Shim {
             name: "GetLastActivePopup",
-            func: impls::GetLastActivePopup,
+            func: shims::Handler::Sync(impls::GetLastActivePopup),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const GetMessageA: Shim = Shim {
+        pub const GetMessageA: shims::Shim = shims::Shim {
             name: "GetMessageA",
-            func: impls::GetMessageA,
+            func: shims::Handler::Async(impls::GetMessageA),
             stack_consumed: 16u32,
-            is_async: true,
         };
-        pub const GetMessageW: Shim = Shim {
+        pub const GetMessageW: shims::Shim = shims::Shim {
             name: "GetMessageW",
-            func: impls::GetMessageW,
+            func: shims::Handler::Async(impls::GetMessageW),
             stack_consumed: 16u32,
-            is_async: true,
         };
-        pub const GetSystemMenu: Shim = Shim {
+        pub const GetSystemMenu: shims::Shim = shims::Shim {
             name: "GetSystemMenu",
-            func: impls::GetSystemMenu,
+            func: shims::Handler::Sync(impls::GetSystemMenu),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const GetSystemMetrics: Shim = Shim {
+        pub const GetSystemMetrics: shims::Shim = shims::Shim {
             name: "GetSystemMetrics",
-            func: impls::GetSystemMetrics,
+            func: shims::Handler::Sync(impls::GetSystemMetrics),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetWindowDC: Shim = Shim {
+        pub const GetWindowDC: shims::Shim = shims::Shim {
             name: "GetWindowDC",
-            func: impls::GetWindowDC,
+            func: shims::Handler::Sync(impls::GetWindowDC),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const GetWindowLongA: Shim = Shim {
+        pub const GetWindowLongA: shims::Shim = shims::Shim {
             name: "GetWindowLongA",
-            func: impls::GetWindowLongA,
+            func: shims::Handler::Sync(impls::GetWindowLongA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const IntersectRect: Shim = Shim {
+        pub const IntersectRect: shims::Shim = shims::Shim {
             name: "IntersectRect",
-            func: impls::IntersectRect,
+            func: shims::Handler::Sync(impls::IntersectRect),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const InvalidateRect: Shim = Shim {
+        pub const InvalidateRect: shims::Shim = shims::Shim {
             name: "InvalidateRect",
-            func: impls::InvalidateRect,
+            func: shims::Handler::Sync(impls::InvalidateRect),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const InvalidateRgn: Shim = Shim {
+        pub const InvalidateRgn: shims::Shim = shims::Shim {
             name: "InvalidateRgn",
-            func: impls::InvalidateRgn,
+            func: shims::Handler::Sync(impls::InvalidateRgn),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const IsIconic: Shim = Shim {
+        pub const IsIconic: shims::Shim = shims::Shim {
             name: "IsIconic",
-            func: impls::IsIconic,
+            func: shims::Handler::Sync(impls::IsIconic),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const IsRectEmpty: Shim = Shim {
+        pub const IsRectEmpty: shims::Shim = shims::Shim {
             name: "IsRectEmpty",
-            func: impls::IsRectEmpty,
+            func: shims::Handler::Sync(impls::IsRectEmpty),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const LoadAcceleratorsW: Shim = Shim {
+        pub const LoadAcceleratorsW: shims::Shim = shims::Shim {
             name: "LoadAcceleratorsW",
-            func: impls::LoadAcceleratorsW,
+            func: shims::Handler::Sync(impls::LoadAcceleratorsW),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const LoadBitmapA: Shim = Shim {
+        pub const LoadBitmapA: shims::Shim = shims::Shim {
             name: "LoadBitmapA",
-            func: impls::LoadBitmapA,
+            func: shims::Handler::Sync(impls::LoadBitmapA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const LoadCursorA: Shim = Shim {
+        pub const LoadCursorA: shims::Shim = shims::Shim {
             name: "LoadCursorA",
-            func: impls::LoadCursorA,
+            func: shims::Handler::Sync(impls::LoadCursorA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const LoadCursorW: Shim = Shim {
+        pub const LoadCursorW: shims::Shim = shims::Shim {
             name: "LoadCursorW",
-            func: impls::LoadCursorW,
+            func: shims::Handler::Sync(impls::LoadCursorW),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const LoadIconA: Shim = Shim {
+        pub const LoadIconA: shims::Shim = shims::Shim {
             name: "LoadIconA",
-            func: impls::LoadIconA,
+            func: shims::Handler::Sync(impls::LoadIconA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const LoadIconW: Shim = Shim {
+        pub const LoadIconW: shims::Shim = shims::Shim {
             name: "LoadIconW",
-            func: impls::LoadIconW,
+            func: shims::Handler::Sync(impls::LoadIconW),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const LoadImageA: Shim = Shim {
+        pub const LoadImageA: shims::Shim = shims::Shim {
             name: "LoadImageA",
-            func: impls::LoadImageA,
+            func: shims::Handler::Sync(impls::LoadImageA),
             stack_consumed: 24u32,
-            is_async: false,
         };
-        pub const LoadImageW: Shim = Shim {
+        pub const LoadImageW: shims::Shim = shims::Shim {
             name: "LoadImageW",
-            func: impls::LoadImageW,
+            func: shims::Handler::Sync(impls::LoadImageW),
             stack_consumed: 24u32,
-            is_async: false,
         };
-        pub const LoadMenuW: Shim = Shim {
+        pub const LoadMenuW: shims::Shim = shims::Shim {
             name: "LoadMenuW",
-            func: impls::LoadMenuW,
+            func: shims::Handler::Sync(impls::LoadMenuW),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const LoadStringA: Shim = Shim {
+        pub const LoadStringA: shims::Shim = shims::Shim {
             name: "LoadStringA",
-            func: impls::LoadStringA,
+            func: shims::Handler::Sync(impls::LoadStringA),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const LoadStringW: Shim = Shim {
+        pub const LoadStringW: shims::Shim = shims::Shim {
             name: "LoadStringW",
-            func: impls::LoadStringW,
+            func: shims::Handler::Sync(impls::LoadStringW),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const MapWindowPoints: Shim = Shim {
+        pub const MapWindowPoints: shims::Shim = shims::Shim {
             name: "MapWindowPoints",
-            func: impls::MapWindowPoints,
+            func: shims::Handler::Sync(impls::MapWindowPoints),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const MessageBoxA: Shim = Shim {
+        pub const MessageBoxA: shims::Shim = shims::Shim {
             name: "MessageBoxA",
-            func: impls::MessageBoxA,
+            func: shims::Handler::Sync(impls::MessageBoxA),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const MessageBoxW: Shim = Shim {
+        pub const MessageBoxW: shims::Shim = shims::Shim {
             name: "MessageBoxW",
-            func: impls::MessageBoxW,
+            func: shims::Handler::Sync(impls::MessageBoxW),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const MoveWindow: Shim = Shim {
+        pub const MoveWindow: shims::Shim = shims::Shim {
             name: "MoveWindow",
-            func: impls::MoveWindow,
+            func: shims::Handler::Sync(impls::MoveWindow),
             stack_consumed: 24u32,
-            is_async: false,
         };
-        pub const MsgWaitForMultipleObjects: Shim = Shim {
+        pub const MsgWaitForMultipleObjects: shims::Shim = shims::Shim {
             name: "MsgWaitForMultipleObjects",
-            func: impls::MsgWaitForMultipleObjects,
+            func: shims::Handler::Sync(impls::MsgWaitForMultipleObjects),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const PeekMessageA: Shim = Shim {
+        pub const PeekMessageA: shims::Shim = shims::Shim {
             name: "PeekMessageA",
-            func: impls::PeekMessageA,
+            func: shims::Handler::Sync(impls::PeekMessageA),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const PeekMessageW: Shim = Shim {
+        pub const PeekMessageW: shims::Shim = shims::Shim {
             name: "PeekMessageW",
-            func: impls::PeekMessageW,
+            func: shims::Handler::Sync(impls::PeekMessageW),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const PostMessageW: Shim = Shim {
+        pub const PostMessageW: shims::Shim = shims::Shim {
             name: "PostMessageW",
-            func: impls::PostMessageW,
+            func: shims::Handler::Sync(impls::PostMessageW),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const PostQuitMessage: Shim = Shim {
+        pub const PostQuitMessage: shims::Shim = shims::Shim {
             name: "PostQuitMessage",
-            func: impls::PostQuitMessage,
+            func: shims::Handler::Sync(impls::PostQuitMessage),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const PtInRect: Shim = Shim {
+        pub const PtInRect: shims::Shim = shims::Shim {
             name: "PtInRect",
-            func: impls::PtInRect,
+            func: shims::Handler::Sync(impls::PtInRect),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const RegisterClassA: Shim = Shim {
+        pub const RegisterClassA: shims::Shim = shims::Shim {
             name: "RegisterClassA",
-            func: impls::RegisterClassA,
+            func: shims::Handler::Sync(impls::RegisterClassA),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const RegisterClassExA: Shim = Shim {
+        pub const RegisterClassExA: shims::Shim = shims::Shim {
             name: "RegisterClassExA",
-            func: impls::RegisterClassExA,
+            func: shims::Handler::Sync(impls::RegisterClassExA),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const RegisterClassExW: Shim = Shim {
+        pub const RegisterClassExW: shims::Shim = shims::Shim {
             name: "RegisterClassExW",
-            func: impls::RegisterClassExW,
+            func: shims::Handler::Sync(impls::RegisterClassExW),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const RegisterClassW: Shim = Shim {
+        pub const RegisterClassW: shims::Shim = shims::Shim {
             name: "RegisterClassW",
-            func: impls::RegisterClassW,
+            func: shims::Handler::Sync(impls::RegisterClassW),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const RegisterWindowMessageW: Shim = Shim {
+        pub const RegisterWindowMessageW: shims::Shim = shims::Shim {
             name: "RegisterWindowMessageW",
-            func: impls::RegisterWindowMessageW,
+            func: shims::Handler::Sync(impls::RegisterWindowMessageW),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const ReleaseCapture: Shim = Shim {
+        pub const ReleaseCapture: shims::Shim = shims::Shim {
             name: "ReleaseCapture",
-            func: impls::ReleaseCapture,
+            func: shims::Handler::Sync(impls::ReleaseCapture),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const ReleaseDC: Shim = Shim {
+        pub const ReleaseDC: shims::Shim = shims::Shim {
             name: "ReleaseDC",
-            func: impls::ReleaseDC,
+            func: shims::Handler::Sync(impls::ReleaseDC),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const SendMessageA: Shim = Shim {
+        pub const SendMessageA: shims::Shim = shims::Shim {
             name: "SendMessageA",
-            func: impls::SendMessageA,
+            func: shims::Handler::Async(impls::SendMessageA),
             stack_consumed: 16u32,
-            is_async: true,
         };
-        pub const SetCapture: Shim = Shim {
+        pub const SetCapture: shims::Shim = shims::Shim {
             name: "SetCapture",
-            func: impls::SetCapture,
+            func: shims::Handler::Sync(impls::SetCapture),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const SetCursor: Shim = Shim {
+        pub const SetCursor: shims::Shim = shims::Shim {
             name: "SetCursor",
-            func: impls::SetCursor,
+            func: shims::Handler::Sync(impls::SetCursor),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const SetFocus: Shim = Shim {
+        pub const SetFocus: shims::Shim = shims::Shim {
             name: "SetFocus",
-            func: impls::SetFocus,
+            func: shims::Handler::Sync(impls::SetFocus),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const SetForegroundWindow: Shim = Shim {
+        pub const SetForegroundWindow: shims::Shim = shims::Shim {
             name: "SetForegroundWindow",
-            func: impls::SetForegroundWindow,
+            func: shims::Handler::Sync(impls::SetForegroundWindow),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const SetMenu: Shim = Shim {
+        pub const SetMenu: shims::Shim = shims::Shim {
             name: "SetMenu",
-            func: impls::SetMenu,
+            func: shims::Handler::Sync(impls::SetMenu),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const SetRect: Shim = Shim {
+        pub const SetRect: shims::Shim = shims::Shim {
             name: "SetRect",
-            func: impls::SetRect,
+            func: shims::Handler::Sync(impls::SetRect),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const SetRectEmpty: Shim = Shim {
+        pub const SetRectEmpty: shims::Shim = shims::Shim {
             name: "SetRectEmpty",
-            func: impls::SetRectEmpty,
+            func: shims::Handler::Sync(impls::SetRectEmpty),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const SetTimer: Shim = Shim {
+        pub const SetTimer: shims::Shim = shims::Shim {
             name: "SetTimer",
-            func: impls::SetTimer,
+            func: shims::Handler::Sync(impls::SetTimer),
             stack_consumed: 16u32,
-            is_async: false,
         };
-        pub const SetWindowPos: Shim = Shim {
+        pub const SetWindowPos: shims::Shim = shims::Shim {
             name: "SetWindowPos",
-            func: impls::SetWindowPos,
+            func: shims::Handler::Async(impls::SetWindowPos),
             stack_consumed: 28u32,
-            is_async: true,
         };
-        pub const SetWindowTextA: Shim = Shim {
+        pub const SetWindowTextA: shims::Shim = shims::Shim {
             name: "SetWindowTextA",
-            func: impls::SetWindowTextA,
+            func: shims::Handler::Sync(impls::SetWindowTextA),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const ShowCursor: Shim = Shim {
+        pub const ShowCursor: shims::Shim = shims::Shim {
             name: "ShowCursor",
-            func: impls::ShowCursor,
+            func: shims::Handler::Sync(impls::ShowCursor),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const ShowWindow: Shim = Shim {
+        pub const ShowWindow: shims::Shim = shims::Shim {
             name: "ShowWindow",
-            func: impls::ShowWindow,
+            func: shims::Handler::Async(impls::ShowWindow),
             stack_consumed: 8u32,
-            is_async: true,
         };
-        pub const TranslateAcceleratorW: Shim = Shim {
+        pub const TranslateAcceleratorW: shims::Shim = shims::Shim {
             name: "TranslateAcceleratorW",
-            func: impls::TranslateAcceleratorW,
+            func: shims::Handler::Sync(impls::TranslateAcceleratorW),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const TranslateMessage: Shim = Shim {
+        pub const TranslateMessage: shims::Shim = shims::Shim {
             name: "TranslateMessage",
-            func: impls::TranslateMessage,
+            func: shims::Handler::Sync(impls::TranslateMessage),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const UpdateWindow: Shim = Shim {
+        pub const UpdateWindow: shims::Shim = shims::Shim {
             name: "UpdateWindow",
-            func: impls::UpdateWindow,
+            func: shims::Handler::Async(impls::UpdateWindow),
             stack_consumed: 4u32,
-            is_async: true,
         };
-        pub const ValidateRect: Shim = Shim {
+        pub const ValidateRect: shims::Shim = shims::Shim {
             name: "ValidateRect",
-            func: impls::ValidateRect,
+            func: shims::Handler::Sync(impls::ValidateRect),
             stack_consumed: 8u32,
-            is_async: false,
         };
-        pub const WaitMessage: Shim = Shim {
+        pub const WaitMessage: shims::Shim = shims::Shim {
             name: "WaitMessage",
-            func: impls::WaitMessage,
+            func: shims::Handler::Sync(impls::WaitMessage),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const wsprintfA: Shim = Shim {
+        pub const wsprintfA: shims::Shim = shims::Shim {
             name: "wsprintfA",
-            func: impls::wsprintfA,
+            func: shims::Handler::Sync(impls::wsprintfA),
             stack_consumed: 0u32,
-            is_async: false,
         };
     }
     const EXPORTS: [Symbol; 87usize] = [
@@ -6263,72 +5661,61 @@ pub mod winmm {
     }
     mod shims {
         use super::impls;
-        use crate::shims::Shim;
-        pub const timeBeginPeriod: Shim = Shim {
+        use crate::shims;
+        pub const timeBeginPeriod: shims::Shim = shims::Shim {
             name: "timeBeginPeriod",
-            func: impls::timeBeginPeriod,
+            func: shims::Handler::Sync(impls::timeBeginPeriod),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const timeGetTime: Shim = Shim {
+        pub const timeGetTime: shims::Shim = shims::Shim {
             name: "timeGetTime",
-            func: impls::timeGetTime,
+            func: shims::Handler::Sync(impls::timeGetTime),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const timeSetEvent: Shim = Shim {
+        pub const timeSetEvent: shims::Shim = shims::Shim {
             name: "timeSetEvent",
-            func: impls::timeSetEvent,
+            func: shims::Handler::Sync(impls::timeSetEvent),
             stack_consumed: 20u32,
-            is_async: false,
         };
-        pub const waveOutClose: Shim = Shim {
+        pub const waveOutClose: shims::Shim = shims::Shim {
             name: "waveOutClose",
-            func: impls::waveOutClose,
+            func: shims::Handler::Sync(impls::waveOutClose),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const waveOutGetDevCapsA: Shim = Shim {
+        pub const waveOutGetDevCapsA: shims::Shim = shims::Shim {
             name: "waveOutGetDevCapsA",
-            func: impls::waveOutGetDevCapsA,
+            func: shims::Handler::Sync(impls::waveOutGetDevCapsA),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const waveOutGetNumDevs: Shim = Shim {
+        pub const waveOutGetNumDevs: shims::Shim = shims::Shim {
             name: "waveOutGetNumDevs",
-            func: impls::waveOutGetNumDevs,
+            func: shims::Handler::Sync(impls::waveOutGetNumDevs),
             stack_consumed: 0u32,
-            is_async: false,
         };
-        pub const waveOutGetPosition: Shim = Shim {
+        pub const waveOutGetPosition: shims::Shim = shims::Shim {
             name: "waveOutGetPosition",
-            func: impls::waveOutGetPosition,
+            func: shims::Handler::Sync(impls::waveOutGetPosition),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const waveOutOpen: Shim = Shim {
+        pub const waveOutOpen: shims::Shim = shims::Shim {
             name: "waveOutOpen",
-            func: impls::waveOutOpen,
+            func: shims::Handler::Sync(impls::waveOutOpen),
             stack_consumed: 24u32,
-            is_async: false,
         };
-        pub const waveOutPrepareHeader: Shim = Shim {
+        pub const waveOutPrepareHeader: shims::Shim = shims::Shim {
             name: "waveOutPrepareHeader",
-            func: impls::waveOutPrepareHeader,
+            func: shims::Handler::Sync(impls::waveOutPrepareHeader),
             stack_consumed: 12u32,
-            is_async: false,
         };
-        pub const waveOutReset: Shim = Shim {
+        pub const waveOutReset: shims::Shim = shims::Shim {
             name: "waveOutReset",
-            func: impls::waveOutReset,
+            func: shims::Handler::Sync(impls::waveOutReset),
             stack_consumed: 4u32,
-            is_async: false,
         };
-        pub const waveOutWrite: Shim = Shim {
+        pub const waveOutWrite: shims::Shim = shims::Shim {
             name: "waveOutWrite",
-            func: impls::waveOutWrite,
+            func: shims::Handler::Sync(impls::waveOutWrite),
             stack_consumed: 12u32,
-            is_async: false,
         };
     }
     const EXPORTS: [Symbol; 11usize] = [

--- a/win32/src/winapi/kernel32/misc.rs
+++ b/win32/src/winapi/kernel32/misc.rs
@@ -32,12 +32,7 @@ pub fn GetLastError(machine: &mut Machine) -> u32 {
 #[win32_derive::dllexport]
 pub fn ExitProcess(machine: &mut Machine, uExitCode: u32) -> u32 {
     machine.host.exit(uExitCode);
-    // TODO: this is unsatisfying.
-    // Maybe better is to generate a hlt instruction somewhere and jump to it?
-    #[cfg(feature = "x86-emu")]
-    {
-        machine.emu.x86.cpu_mut().state = x86::CPUState::Exit(uExitCode);
-    }
+    machine.exit(uExitCode);
     0
 }
 

--- a/x86/Cargo.toml
+++ b/x86/Cargo.toml
@@ -8,6 +8,7 @@ log = { workspace = true }
 memory = { workspace = true }
 
 bitflags = "1.3.2"
+futures = "0.3.30"
 iced-x86 = "1.17.0"
 num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/x86/src/icache.rs
+++ b/x86/src/icache.rs
@@ -29,7 +29,7 @@ pub struct BasicBlock {
 }
 
 impl BasicBlock {
-    fn decode(buf: Mem, ip: u32, single_step: bool) -> Option<Self> {
+    fn decode(buf: Mem, ip: u32, mut instruction_count: usize) -> Option<Self> {
         let mut ops = Vec::new();
         let mut decoder = iced_x86::Decoder::with_ip(
             32,
@@ -64,8 +64,14 @@ impl BasicBlock {
                 crate::ops::decode(&instr).unwrap_or_else(|| todo!("{instr} ({:?})", instr.code()));
             ops.push(Op { op, instr });
             len += instr.len() as u32;
-            if instr.flow_control() != iced_x86::FlowControl::Next || single_step {
+            if instr.flow_control() != iced_x86::FlowControl::Next {
                 break;
+            }
+            if instruction_count > 0 {
+                instruction_count -= 1;
+                if instruction_count == 0 {
+                    break;
+                }
             }
         }
         Some(BasicBlock { ops, len })
@@ -118,8 +124,8 @@ impl InstrCache {
     }
 
     /// Decode the instructions starting at ip and save in self.lines.
-    fn decode_block(&mut self, mem: Mem, ip: u32, single_step: bool) -> &BasicBlock {
-        let block = match BasicBlock::decode(mem.slice(ip..), ip, single_step) {
+    fn decode_block(&mut self, mem: Mem, ip: u32, instruction_count: usize) -> &BasicBlock {
+        let block = match BasicBlock::decode(mem.slice(ip..), ip, instruction_count) {
             Some(block) => block,
             None => unreachable!(),
         };
@@ -141,20 +147,18 @@ impl InstrCache {
     }
 
     /// Gets basic block starting at a given ip.
-    pub fn get_block<'a>(&'a mut self, mem: Mem, ip: u32) -> &'a BasicBlock {
+    pub fn get_block(&mut self, mem: Mem, ip: u32, instruction_count: usize) -> &BasicBlock {
+        if instruction_count > 0 {
+            // If we're single-stepping, we don't want to cache the block.
+            return self.decode_block(mem, ip, instruction_count);
+        }
         let index = ip as usize % self.lines.len();
         if self.lines[index].ip == ip {
             self.hit += 1;
             return &self.lines[index].block;
         } else {
             self.miss += 1;
-            self.decode_block(mem, ip, false)
+            self.decode_block(mem, ip, 0)
         }
-    }
-
-    /// Change cache such that there's a single basic block at ip.
-    /// This means the next get_block() will get a block with a single instruction.
-    pub fn make_single_step(&mut self, mem: Mem, ip: u32) {
-        self.decode_block(mem, ip, true);
     }
 }

--- a/x86/src/lib.rs
+++ b/x86/src/lib.rs
@@ -7,3 +7,4 @@ mod x86;
 
 pub use crate::x86::{CPUState, CPU, X86};
 pub use iced_x86::Register;
+pub use registers::Flags;

--- a/x86/src/x86.rs
+++ b/x86/src/x86.rs
@@ -8,6 +8,9 @@ use crate::{
     Register,
 };
 use memory::Mem;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::Context;
 
 #[derive(Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum CPUState {
@@ -42,7 +45,7 @@ pub struct CPU {
     /// If eip==MAGIC_ADDR, then the next step is to poll a future rather than
     /// executing a basic block.
     #[serde(skip)]
-    futures: Vec<std::pin::Pin<Box<dyn std::future::Future<Output = ()>>>>,
+    futures: Vec<Pin<Box<dyn Future<Output = ()>>>>,
 }
 
 impl CPU {
@@ -100,24 +103,20 @@ impl CPU {
 
     /// Set up the CPU such that we are making an x86->async call, enqueuing a Future
     /// that is polled the next time the CPU executes.
-    pub fn call_async(&mut self, future: std::pin::Pin<Box<dyn std::future::Future<Output = ()>>>) {
+    pub fn call_async(&mut self, future: Pin<Box<dyn Future<Output = ()>>>) {
         self.regs.eip = MAGIC_ADDR;
         self.futures.push(future);
     }
 
-    #[allow(deref_nullptr)]
     fn async_executor(&mut self) {
-        let mut future = self.futures.pop().unwrap();
-        // TODO: we don't use the waker at all.  Rust doesn't like us passing a random null pointer
-        // here but it seems like nothing accesses it(?).
-        //let c = unsafe { std::task::Context::from_waker(&Waker::from_raw(std::task::RawWaker::)) };
-        let context: &mut std::task::Context = unsafe { &mut *std::ptr::null_mut() };
-        let poll = future.as_mut().poll(context);
+        let future = self.futures.last_mut().unwrap();
+        let mut ctx = Context::from_waker(futures::task::noop_waker_ref());
+        let poll = future.as_mut().poll(&mut ctx);
         match poll {
-            std::task::Poll::Ready(()) => {}
-            std::task::Poll::Pending => {
-                self.futures.push(future);
+            std::task::Poll::Ready(()) => {
+                self.futures.pop();
             }
+            std::task::Poll::Pending => {}
         }
     }
 
@@ -133,13 +132,10 @@ pub struct X86Future {
     cpu: *mut CPU,
     esp: u32,
 }
-impl std::future::Future for X86Future {
+impl Future for X86Future {
     type Output = u32;
 
-    fn poll(
-        self: std::pin::Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> std::task::Poll<Self::Output> {
         let cpu = self.cpu;
         let cpu = unsafe { &mut *cpu };
         if cpu.regs.get32(Register::ESP) == self.esp {
@@ -157,13 +153,10 @@ pub struct BlockFuture {
     cpu: *mut CPU,
 }
 
-impl std::future::Future for BlockFuture {
+impl Future for BlockFuture {
     type Output = ();
 
-    fn poll(
-        self: std::pin::Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> std::task::Poll<Self::Output> {
         let cpu = self.cpu;
         let cpu = unsafe { &mut *cpu };
         if matches!(cpu.state, CPUState::Blocked(_)) {
@@ -174,24 +167,21 @@ impl std::future::Future for BlockFuture {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
 pub struct X86 {
     /// CPUs are boxed because their futures take pointers to self.
-    /// In theory we could use Pin here but maybe we just need to revisit how this works in general.
-    pub cpus: Vec<Box<CPU>>,
+    pub cpus: Vec<Pin<Box<CPU>>>,
     pub cur_cpu: usize,
 
     /// Total number of instructions executed.
     pub instr_count: usize,
 
-    #[serde(skip)]
     pub icache: InstrCache,
 }
 
 impl X86 {
     pub fn new() -> Self {
         X86 {
-            cpus: vec![Box::new(CPU::new())],
+            cpus: vec![Box::pin(CPU::new())],
             cur_cpu: 0,
             instr_count: 0,
             icache: InstrCache::default(),
@@ -207,16 +197,8 @@ impl X86 {
     }
 
     pub fn new_cpu(&mut self) -> &mut CPU {
-        self.cpus.push(Box::new(CPU::new()));
+        self.cpus.push(Box::pin(CPU::new()));
         self.cpus.last_mut().unwrap()
-    }
-
-    pub fn single_step_next_block(&mut self, mem: Mem) {
-        let ip = self.cpu().regs.eip;
-        if ip == MAGIC_ADDR {
-            return;
-        }
-        self.icache.make_single_step(mem, ip);
     }
 
     /// Schedule the next runnable thread to run.
@@ -266,15 +248,15 @@ impl X86 {
     }
 
     /// Execute one basic block starting at current ip.
-    pub fn execute_block(&mut self, mem: Mem) {
+    pub fn execute_block(&mut self, mem: Mem, instruction_count: usize) -> usize {
         let cpu = &mut *self.cpus[self.cur_cpu];
         debug_assert!(cpu.state.is_running());
         if cpu.regs.eip == MAGIC_ADDR {
             cpu.async_executor();
-            return;
+            return 0;
         }
         let mut prev_ip = cpu.regs.eip;
-        let block = self.icache.get_block(mem, prev_ip);
+        let block = self.icache.get_block(mem, prev_ip, instruction_count);
         for op in block.ops.iter() {
             prev_ip = cpu.regs.eip;
             cpu.regs.eip = op.instr.next_ip() as u32;
@@ -291,5 +273,6 @@ impl X86 {
             }
             _ => {}
         }
+        block.len as usize
     }
 }


### PR DESCRIPTION
This implements a working GDB stub for `x86-emu` and `x86-unicorn`. One larger change is the new state machine in `cli/main.rs`. This code is now shared between `x86-emu` and `x86-unicorn`: it allows stopping, resuming and single-stepping the machine emulation, handling breakpoints and machine errors in a unified way.

Another larger change is reworking the async shim handling. There's no longer any backend-specific code in `builtin.rs`. (Take a look at the simplified implementation!) `x86-unicorn` was updated to use the `x86-emu` approach for future handling (using `eip=MAGIC_ADDR` to poll futures instead of executing CPU), though I'd like to consider ideas to unify this code between the two as well, if possible.

Other changes:
- `x86-unicorn`: Unmapped first 4k of memory to catch zero page accesses
- Removed `--trace-points` in favor of GDB breakpoints
- Removed `--trace-blocks` because I didn't feel like reimplementing it (I could, though, if desired)
- Removed `x86-emu` snapshot feature. I broke it while refactoring things to use `Pin<>`, and decided to rip it out and revisit later if it's still a desired feature. One big issue is that it's incompatible with any running futures.

TODO:
- [ ] Fix `x86-64` build
- [ ] Fix web build