### PR TITLE
Zero out entire struct in GetStartupInfoA

### DIFF
--- a/win32/src/winapi/kernel32/dll.rs
+++ b/win32/src/winapi/kernel32/dll.rs
@@ -322,8 +322,11 @@ unsafe impl ::memory::Pod for STARTUPINFOA {}
 pub fn GetStartupInfoA(_machine: &mut Machine, lpStartupInfo: Option<&mut STARTUPINFOA>) -> u32 {
     // MSVC runtime library passes in uninitialized memory for lpStartupInfo, so don't trust info.cb.
     let info = lpStartupInfo.unwrap();
-    let len = std::cmp::min(info.cb, std::mem::size_of::<STARTUPINFOA>() as u32);
+    let len = std::mem::size_of::<STARTUPINFOA>() as u32;
     unsafe { info.clear_memory(len) };
+
+    info.cb = len;
+
     0
 }
 


### PR DESCRIPTION
As I've understand `GetStartupInfoA`, the caller always passes a pointer to uninitialized memory, and the function will then fill in the values. Before this change, `GetStartupInfoA` read the value of `cb` as an input parameter to get the length of the struct. In my program that part of the memory was uninitialized and happened to be 0, so the rest of the values were never zeroed out, leading to garbage data being returned in the other field.

This change make sure to zero out the entire struct, and then sets `cb` to the actual length of the struct.

Lifted from #39