### PR TITLE
add handles for events

### DIFF
--- a/win32/src/winapi/builtin.rs
+++ b/win32/src/winapi/builtin.rs
@@ -2937,7 +2937,7 @@ pub mod kernel32 {
         }
         pub unsafe fn SetEvent(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
-            let hEvent = <HANDLE<()>>::from_stack(mem, esp + 4u32);
+            let hEvent = <HEVENT>::from_stack(mem, esp + 4u32);
             winapi::kernel32::SetEvent(machine, hEvent).to_raw()
         }
         pub unsafe fn SetFileAttributesA(machine: &mut Machine, esp: u32) -> u32 {
@@ -3131,7 +3131,7 @@ pub mod kernel32 {
         }
         pub unsafe fn WaitForSingleObject(machine: &mut Machine, esp: u32) -> u32 {
             let mem = machine.mem().detach();
-            let hHandle = <HANDLE<()>>::from_stack(mem, esp + 4u32);
+            let hHandle = <HEVENT>::from_stack(mem, esp + 4u32);
             let dwMilliseconds = <u32>::from_stack(mem, esp + 8u32);
             winapi::kernel32::WaitForSingleObject(machine, hHandle, dwMilliseconds).to_raw()
         }

--- a/win32/src/winapi/kernel32/init.rs
+++ b/win32/src/winapi/kernel32/init.rs
@@ -1,6 +1,6 @@
 //! Process initialization and startup.
 
-use super::{FindHandle, Mappings, ResourceHandle, DLL, HMODULE, STDERR_HFILE, STDOUT_HFILE};
+use super::{EventObject, FindHandle, Mappings, ResourceHandle, DLL, HMODULE, STDERR_HFILE, STDOUT_HFILE};
 use crate::{
     machine::MemImpl,
     pe,
@@ -211,6 +211,8 @@ pub struct State {
     pub resources: pe::IMAGE_DATA_DIRECTORY,
     pub resource_handles: Handles<HRSRC, ResourceHandle>,
 
+    pub event_handles: Handles<HEVENT, EventObject>,
+
     pub files: Handles<HFILE, Box<dyn crate::host::File>>,
 
     pub find_handles: Handles<HFIND, FindHandle>,
@@ -244,6 +246,7 @@ impl State {
             mappings,
             heaps: HashMap::new(),
             dlls: Default::default(),
+            event_handles: Default::default(),
             files: Default::default(),
             find_handles: Default::default(),
             env: env_addr,

--- a/win32/src/winapi/kernel32/sync.rs
+++ b/win32/src/winapi/kernel32/sync.rs
@@ -4,7 +4,9 @@ use crate::{winapi::types::HEVENT, Machine};
 
 const TRACE_CONTEXT: &'static str = "kernel32/misc";
 
-pub struct EventObject;
+pub struct EventObject {
+    state: bool,
+}
 
 #[win32_derive::dllexport]
 pub fn WaitForSingleObject(
@@ -27,10 +29,19 @@ pub fn CreateEventA(
         todo!("CreateEventA: named events not supported");
     }
 
-    machine.state.kernel32.event_handles.add(EventObject)
+    machine.state.kernel32.event_handles.add(EventObject { state: false })
 }
 
 #[win32_derive::dllexport]
-pub fn SetEvent(_machine: &mut Machine, hEvent: HEVENT) -> bool {
-    todo!()
+pub fn SetEvent(machine: &mut Machine, hEvent: HEVENT) -> bool {
+    match machine.state.kernel32.event_handles.get_mut(hEvent) {
+        Some(handle) => {
+            handle.state = true;
+            true
+        }
+        None => {
+            log::warn!("SetEvent: invalid handle");
+            false
+        }
+    }
 }

--- a/win32/src/winapi/kernel32/sync.rs
+++ b/win32/src/winapi/kernel32/sync.rs
@@ -1,13 +1,15 @@
 //! Synchronization.  Currently all no-ops as we don't support threads.
 
-use crate::{winapi::types::HANDLE, Machine};
+use crate::{winapi::types::HEVENT, Machine};
 
 const TRACE_CONTEXT: &'static str = "kernel32/misc";
+
+pub struct EventObject;
 
 #[win32_derive::dllexport]
 pub fn WaitForSingleObject(
     _machine: &mut Machine,
-    hHandle: HANDLE<()>,
+    hHandle: HEVENT,
     dwMilliseconds: u32,
 ) -> u32 {
     todo!()
@@ -15,16 +17,20 @@ pub fn WaitForSingleObject(
 
 #[win32_derive::dllexport]
 pub fn CreateEventA(
-    _machine: &mut Machine,
+    machine: &mut Machine,
     lpEventAttributes: u32,
     bManualReset: bool,
     bInitialState: bool,
     lpName: Option<&str>,
-) -> HANDLE<()> {
-    todo!()
+) -> HEVENT {
+    if lpName.is_some() {
+        todo!("CreateEventA: named events not supported");
+    }
+
+    machine.state.kernel32.event_handles.add(EventObject)
 }
 
 #[win32_derive::dllexport]
-pub fn SetEvent(_machine: &mut Machine, hEvent: HANDLE<()>) -> bool {
+pub fn SetEvent(_machine: &mut Machine, hEvent: HEVENT) -> bool {
     todo!()
 }

--- a/win32/src/winapi/types.rs
+++ b/win32/src/winapi/types.rs
@@ -8,6 +8,10 @@ pub type WORD = u16;
 pub type DWORD = u32;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct HEVENTT;
+pub type HEVENT = HANDLE<HEVENTT>;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct HFILET;
 pub type HFILE = HANDLE<HFILET>;
 


### PR DESCRIPTION
Which makes `CreateEventA` works when called without a name, and also implements `SetEvent`