### PR TITLE
implement GetWindowPlacement

### DIFF
--- a/win32/src/winapi/builtin.rs
+++ b/win32/src/winapi/builtin.rs
@@ -12425,7 +12425,7 @@ pub mod user32 {
         pub unsafe fn GetWindowPlacement(machine: &mut Machine, stack_args: u32) -> u32 {
             let mem = machine.mem().detach();
             let hWnd = <HWND>::from_stack(mem, stack_args + 0u32);
-            let lpwndpl = <Option<&mut u32>>::from_stack(mem, stack_args + 4u32);
+            let lpwndpl = <Option<&mut WINDOWPLACEMENT>>::from_stack(mem, stack_args + 4u32);
             let __trace_context = if crate::trace::enabled("user32/window") {
                 Some(crate::trace::trace_begin(
                     "user32/window",

--- a/win32/src/winapi/types.rs
+++ b/win32/src/winapi/types.rs
@@ -30,7 +30,7 @@ pub struct HWNDT;
 pub type HWND = HANDLE<HWNDT>;
 
 #[repr(C, packed)]
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct RECT {
     pub left: i32,
     pub top: i32,


### PR DESCRIPTION
Opening this to get some discussion around how to implement variable length structs 🤔 

According to MSDN:

> [...] Before calling `GetWindowPlacement`, set the `length` member to `sizeof(WINDOWPLACEMENT)`. `GetWindowPlacement` fails if `lpwndpl->length` is not set correctly.

[ref](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowplacement)

The problem is that [my program (Pocoman)](https://github.com/evmar/retrowin32/issues/43) doesn't seem to initialize the `length` property at all. From looking at Ghidra I _think_ that the variable simply isn't initialized at all, so it has the value of whatever happened to be in that stack position previously. (note that I don't have much experience with this so I could absolutely be wrong)

Here is what `dbg!(&wndpl);` prints:

```text
&wndpl = WINDOWPLACEMENT {
    length: 50078,
    flags: 4265673,
    showCmd: 4379564,
    ptMinPosition: POINT {
        x: 4260799,
        y: 4,
    },
    ptMaxPosition: POINT {
        x: 4,
        y: 4,
    },
    rcNormalPosition: RECT {
        left: 0,
        top: 50078,
        right: 4247973,
        bottom: 1183232,
    },
    rcDevice: RECT {
        left: 63,
        top: 5,
        right: 16,
        bottom: 4194304,
    },
}
```

I'm not really sure what to do here. I'm guessing that the input characteristics of `length` was introduced in a later version, in order to add `rcDevice` in a backwards compatible way. But I don't understand how that could be since presumable it has been called with uninitialized data for `length` before that 🤔 