### PR TITLE
Reduce get_state duplication

### DIFF
--- a/win32/dll/ddraw/src/ddraw.rs
+++ b/win32/dll/ddraw/src/ddraw.rs
@@ -6,12 +6,8 @@ use super::{ddraw1, ddraw7, palette::Palette};
 use builtin_gdi32::bitmap::{Bitmap, PixelData, PixelFormat, transmute_pixels_mut};
 use builtin_user32 as user32;
 use memory::{Extensions, ExtensionsMut, Mem};
-use std::{
-    cell::{RefCell, RefMut},
-    collections::HashMap,
-    rc::Rc,
-};
-use win32_system::{Heap, System, host};
+use std::{cell::RefMut, collections::HashMap, rc::Rc};
+use win32_system::{Heap, System, generic_get_state, host};
 use win32_winapi::{HWND, RECT, com::GUID};
 
 pub struct Surface {
@@ -224,13 +220,9 @@ impl Default for State {
     }
 }
 
+#[inline]
 pub fn get_state(sys: &dyn System) -> RefMut<State> {
-    sys.state(&std::any::TypeId::of::<RefCell<State>>(), || {
-        Box::new(RefCell::new(State::default()))
-    })
-    .downcast_ref::<RefCell<State>>()
-    .unwrap()
-    .borrow_mut()
+    generic_get_state::<State>(sys)
 }
 
 #[win32_derive::dllexport]

--- a/win32/dll/gdi32/src/state.rs
+++ b/win32/dll/gdi32/src/state.rs
@@ -1,7 +1,7 @@
 use crate::dc::{DC, DCTarget, HDC, ScreenDCTarget};
 use crate::{HGDIOBJ, LOWEST_HGDIOBJ, Object, bitmap::Bitmap};
 use std::{cell::RefCell, rc::Rc};
-use win32_system::System;
+use win32_system::{System, generic_get_state};
 use win32_winapi::Handles;
 
 pub struct State {
@@ -60,12 +60,7 @@ impl State {
     }
 }
 
+#[inline]
 pub fn get_state(sys: &dyn System) -> std::cell::RefMut<State> {
-    type SysState = std::cell::RefCell<State>;
-    sys.state(&std::any::TypeId::of::<SysState>(), || {
-        Box::new(RefCell::new(State::default()))
-    })
-    .downcast_ref::<SysState>()
-    .unwrap()
-    .borrow_mut()
+    generic_get_state::<State>(sys)
 }

--- a/win32/dll/kernel32/src/file/find.rs
+++ b/win32/dll/kernel32/src/file/find.rs
@@ -1,6 +1,6 @@
 use super::FileAttribute;
 use crate::FILETIME;
-use win32_system::{System, host};
+use win32_system::{System, generic_get_state, host};
 use win32_winapi::{DWORD, ERROR, HANDLE, Handles, Str16, WindowsPath};
 
 use super::HFILE;
@@ -12,14 +12,9 @@ pub type HFIND = HANDLE<HFINDT>;
 
 type State = Handles<HFIND, FindHandle>;
 
-fn get_state(sys: &dyn System) -> std::cell::RefMut<State> {
-    type SysState = std::cell::RefCell<State>;
-    sys.state(&std::any::TypeId::of::<SysState>(), || {
-        Box::new(std::cell::RefCell::new(State::default()))
-    })
-    .downcast_ref::<SysState>()
-    .unwrap()
-    .borrow_mut()
+#[inline]
+pub fn get_state(sys: &dyn System) -> std::cell::RefMut<State> {
+    generic_get_state::<State>(sys)
 }
 
 #[repr(C)]

--- a/win32/dll/kernel32/src/file/mod.rs
+++ b/win32/dll/kernel32/src/file/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod stdio;
 pub use file::{HFILE, write_file};
 pub use metadata::FileAttribute;
 pub use stdio::{STDERR_HFILE, STDIN_HFILE, STDOUT_HFILE};
-use win32_system::{System, host};
+use win32_system::{System, generic_get_state, host};
 use win32_winapi::Handles;
 
 #[derive(Default)]
@@ -19,12 +19,7 @@ pub struct State {
     pub files: Handles<HFILE, Box<dyn host::File>>,
 }
 
-pub fn get_state(sys: &dyn System) -> ::std::cell::RefMut<State> {
-    type SysState = ::std::cell::RefCell<State>;
-    sys.state(&::std::any::TypeId::of::<SysState>(), || {
-        Box::new(::std::cell::RefCell::new(State::default()))
-    })
-    .downcast_ref::<SysState>()
-    .unwrap()
-    .borrow_mut()
+#[inline]
+pub fn get_state(sys: &dyn System) -> std::cell::RefMut<State> {
+    generic_get_state::<State>(sys)
 }

--- a/win32/dll/kernel32/src/resource.rs
+++ b/win32/dll/kernel32/src/resource.rs
@@ -1,5 +1,5 @@
 use std::ops::Range;
-use win32_system::{System, resource::find_resource};
+use win32_system::{System, generic_get_state, resource::find_resource};
 use win32_winapi::{HANDLE, HMODULE, Handles, Str16};
 
 pub use win32_system::resource::ResourceKey;
@@ -12,14 +12,9 @@ pub struct ResourceHandle(Range<u32>);
 
 type State = Handles<HRSRC, ResourceHandle>;
 
-fn get_state(sys: &dyn System) -> std::cell::RefMut<State> {
-    type SysState = std::cell::RefCell<State>;
-    sys.state(&std::any::TypeId::of::<SysState>(), || {
-        Box::new(SysState::default())
-    })
-    .downcast_ref::<SysState>()
-    .unwrap()
-    .borrow_mut()
+#[inline]
+pub fn get_state(sys: &dyn System) -> std::cell::RefMut<State> {
+    generic_get_state::<State>(sys)
 }
 
 #[win32_derive::dllexport]

--- a/win32/dll/kernel32/src/state.rs
+++ b/win32/dll/kernel32/src/state.rs
@@ -1,6 +1,6 @@
 use super::{HEVENT, Thread, command_line, init::init_peb, loader::Module};
 use std::{collections::HashMap, rc::Rc, sync::Arc};
-use win32_system::{Event, System, memory::Memory};
+use win32_system::{Event, System, generic_get_state, memory::Memory};
 use win32_winapi::{HANDLE, HMODULE, Handles};
 
 /// Objects identified by kernel handles, all of which can be passed to Wait* functions.
@@ -62,12 +62,7 @@ impl State {
     }
 }
 
+#[inline]
 pub fn get_state(sys: &dyn System) -> std::cell::RefMut<State> {
-    type SysState = std::cell::RefCell<State>;
-    sys.state(&std::any::TypeId::of::<SysState>(), || {
-        Box::new(std::cell::RefCell::new(State::default()))
-    })
-    .downcast_ref::<SysState>()
-    .unwrap()
-    .borrow_mut()
+    generic_get_state::<State>(sys)
 }

--- a/win32/dll/user32/src/state.rs
+++ b/win32/dll/user32/src/state.rs
@@ -6,7 +6,7 @@ use crate::{
     wndclass::{CS, WndClass, WndClasses},
 };
 use std::{cell::RefCell, rc::Rc};
-use win32_system::System;
+use win32_system::{System, generic_get_state};
 use win32_winapi::{HWND, Handles};
 
 pub struct State {
@@ -65,12 +65,7 @@ impl State {
     }
 }
 
+#[inline]
 pub fn get_state(sys: &dyn System) -> std::cell::RefMut<State> {
-    type SysState = std::cell::RefCell<State>;
-    sys.state(&std::any::TypeId::of::<SysState>(), || {
-        Box::new(RefCell::new(State::default()))
-    })
-    .downcast_ref::<SysState>()
-    .unwrap()
-    .borrow_mut()
+    generic_get_state::<State>(sys)
 }

--- a/win32/dll/winmm/src/lib.rs
+++ b/win32/dll/winmm/src/lib.rs
@@ -12,10 +12,10 @@ mod time;
 mod wave;
 
 pub use builtin::DLL;
-use std::cell::{RefCell, RefMut};
+use std::cell::RefMut;
 use time::TimeThread;
 use wave::WaveState;
-use win32_system::System;
+use win32_system::{System, generic_get_state};
 use win32_winapi::calling_convention::ABIReturn;
 
 #[derive(Copy, Clone, Debug)]
@@ -30,6 +30,7 @@ impl Into<ABIReturn> for MMRESULT {
     }
 }
 
+// TODO: we could have separate state for wave and time.
 #[derive(Default)]
 pub struct State {
     pub audio_enabled: bool,
@@ -37,13 +38,7 @@ pub struct State {
     pub wave: WaveState,
 }
 
+#[inline]
 pub fn get_state(sys: &dyn System) -> RefMut<State> {
-    // TODO: we could have separate state for wave and time.
-    type SysState = RefCell<State>;
-    sys.state(&std::any::TypeId::of::<SysState>(), || {
-        Box::new(RefCell::new(State::default()))
-    })
-    .downcast_ref::<SysState>()
-    .unwrap()
-    .borrow_mut()
+    generic_get_state::<State>(sys)
 }

--- a/win32/system/src/lib.rs
+++ b/win32/system/src/lib.rs
@@ -10,5 +10,5 @@ mod wait;
 
 pub use event::{ArcEvent, Event};
 pub use heap::Heap;
-pub use system::System;
+pub use system::{System, generic_get_state};
 pub use wait::{Wait, WaitResult};

--- a/win32/system/src/system.rs
+++ b/win32/system/src/system.rs
@@ -83,3 +83,15 @@ pub trait System {
         init: fn() -> Box<dyn std::any::Any>,
     ) -> &dyn std::any::Any;
 }
+
+pub fn generic_get_state<T>(sys: &dyn System) -> std::cell::RefMut<T>
+where
+    T: 'static + Default,
+{
+    sys.state(&std::any::TypeId::of::<T>(), || {
+        Box::new(std::cell::RefCell::new(T::default()))
+    })
+    .downcast_ref::<std::cell::RefCell<T>>()
+    .unwrap()
+    .borrow_mut()
+}


### PR DESCRIPTION
Introduces `win32_system::generic_get_state` that handles fetching/initializing, downcasting and borrowing a state object.