### PR TITLE
Try all dll_paths in find_dll

### DIFF
--- a/win32/dll/kernel32/src/loader.rs
+++ b/win32/dll/kernel32/src/loader.rs
@@ -448,9 +448,9 @@ fn find_dll(sys: &dyn System, filename: &str) -> anyhow::Result<Vec<u8>> {
     let dll_paths = [format!("{exe_dir}\\{filename}"), filename.to_string()];
     for path in &dll_paths {
         let path = WindowsPath::new(path);
-        let buf = read_file(sys.host(), path)?;
-        if !buf.is_empty() {
-            return Ok(buf);
+        match read_file(sys.host(), path) {
+            Ok(buf) if !buf.is_empty() => return Ok(buf),
+            _ => continue,
         }
     }
     anyhow::bail!("{filename:?} not found in {dll_paths:?}");


### PR DESCRIPTION
My program was calling `LoadLibraryA` with a full path, which then failed as it first tried reading the full path added to the current directory, and bailed early. It seems like the original intent was to try both, but the `?` introduces an early return path...