### PR TITLE
Implement bts_rm16_imm8

### DIFF
--- a/x86/src/ops/bits.rs
+++ b/x86/src/ops/bits.rs
@@ -25,6 +25,15 @@ pub fn bts_rm32_r32(cpu: &mut CPU, mem: Mem, instr: &Instruction) {
     x.set(x.get() | mask);
 }
 
+/// bts: Bit Test and Set
+pub fn bts_rm16_imm8(cpu: &mut CPU, mem: Mem, instr: &Instruction) {
+    let y = instr.immediate8() % 16;
+    let x = rm16(cpu, mem, instr);
+    let mask = 1u16 << y;
+    cpu.flags.set(Flags::CF, x.get() & mask != 0);
+    x.set(x.get() | mask);
+}
+
 /// btr: Bit Test and Reset
 pub fn btr_rm32_imm8(cpu: &mut CPU, mem: Mem, instr: &Instruction) {
     let y = instr.immediate8() % 32;

--- a/x86/src/ops/table.rs
+++ b/x86/src/ops/table.rs
@@ -529,6 +529,7 @@ const OP_TAB: [Option<OpImp>; 2553] = {
     tab[iced_x86::Code::Bswap_r32 as usize] = Some(bswap_r32);
     tab[iced_x86::Code::Xlat_m8 as usize] = Some(xlat_m8);
     tab[iced_x86::Code::Bts_rm32_r32 as usize] = Some(bts_rm32_r32);
+    tab[iced_x86::Code::Bts_rm16_imm8 as usize] = Some(bts_rm16_imm8);
     tab[iced_x86::Code::Tzcnt_r32_rm32 as usize] = Some(tzcnt_r32_rm32);
 
     tab[iced_x86::Code::Cpuid as usize] = Some(cpuid);


### PR DESCRIPTION
I used Claude Sonnet 4.5 to generate this function. Looking at the other functions around, it _seems_ correct to me. 

Reading some documentation I found [here](https://docs.oracle.com/cd/E19620-01/805-4693/805-4693.pdf) unfortunately didn't make me any wiser 😅 

