### PR TITLE
Implement fbld_m80bcd instruction

### DIFF
--- a/x86/src/ops/table.rs
+++ b/x86/src/ops/table.rs
@@ -373,6 +373,7 @@ const OP_TAB: [Option<OpImp>; 2553] = {
     tab[iced_x86::Code::Fild_m64int as usize] = Some(fild_m64int);
     tab[iced_x86::Code::Fild_m32int as usize] = Some(fild_m32int);
     tab[iced_x86::Code::Fild_m16int as usize] = Some(fild_m16int);
+    tab[iced_x86::Code::Fbld_m80bcd as usize] = Some(fbld_m80bcd);
     tab[iced_x86::Code::Fst_m64fp as usize] = Some(fst_m64fp);
     tab[iced_x86::Code::Fst_m32fp as usize] = Some(fst_m32fp);
     tab[iced_x86::Code::Fstp_m64fp as usize] = Some(fstp_m64fp);


### PR DESCRIPTION
Documentation: https://www.felixcloutier.com/x86/fbld

⚠️ Claude Sonnet 4.5 wrote the code,

and I've tried my best to verify it against the documentation, but at the end of the day I don't have a great way to verify that the implementation is 100% correct 😅 

I also tried finding any bcd functions built into Rust, that would actually emit code that uses this instruction (e.g. `f64::from_bcd([u8; 10])` would have been nice 😁) but couldn't find any. So this contains code to actually do the BCD decoding.

Maybe this is not desirable? I'm very open to any other approaches!

Also, if you want me to do any changes to the code I'm happy to, it's a bit "chatty" now with the comments? But it did help me understand what's going on...

I'm also wondering if upping the multipler for each iteration is the way to go, or multiplying the result by 10 every time would be better 🤔 